### PR TITLE
Allow to send keydown events to the outside.

### DIFF
--- a/addon/components/ember-basic-dropdown.js
+++ b/addon/components/ember-basic-dropdown.js
@@ -21,25 +21,19 @@ export default Component.extend({
     this.handleRootClick = this.handleRootClick.bind(this);
     this.handleRepositioningEvent = this.handleRepositioningEvent.bind(this);
     this.repositionDropdown = this.repositionDropdown.bind(this);
+    this.publicAPI = {
+      open: this.open.bind(this),
+      close: this.close.bind(this),
+      toggle: this._actions.toggle.bind(this)
+    };
   },
 
   didInitAttrs() {
     this._super(...arguments);
     const registerActionsInParent = this.get('registerActionsInParent');
     if (registerActionsInParent) {
-      registerActionsInParent({
-        open: this.open.bind(this),
-        close: this.close.bind(this),
-        toggle: this._actions.toggle.bind(this)
-      });
+      registerActionsInParent(this.publicAPI);
     }
-  },
-
-  didInsertElement() {
-    this._super(...arguments);
-    this.element.addEventListener('dropdown:toggle', e => this.toggle(e));
-    this.element.addEventListener('dropdown:open', e => this.open(e));
-    this.element.addEventListener('dropdown:close', e => this.close(e, true));
   },
 
   willDestroy() {
@@ -98,13 +92,14 @@ export default Component.extend({
 
   handleKeydown(e) {
     if (this.get('disabled')) { return; }
+    let onKeydown = this.get('onKeydown');
+    if (onKeydown) { onKeydown(this.publicAPI, e); }
+    if (e.defaultPrevented) { return; }
     if (e.keyCode === 13) {  // Enter
       this.toggle(e);
     } else if (e.keyCode === 27) {
       this.close(e);
     }
-    let onKeydown = this.get('onKeydown');
-    if (onKeydown) { onKeydown(e); }
   },
 
   repositionDropdown() {

--- a/addon/templates/components/ember-basic-dropdown.hbs
+++ b/addon/templates/components/ember-basic-dropdown.hbs
@@ -4,7 +4,7 @@
 {{#if _opened}}
   {{#ember-wormhole to=_wormholeDestination renderInPlace=renderInPlace}}
     <div class="ember-basic-dropdown-content {{dropdownClass}} {{_dropdownPositionClass}}">
-      {{yield (hash open=(action open) close=(action close) toggle=(action toggle))}}
+      {{yield publicAPI}}
     </div>
   {{/ember-wormhole}}
 {{/if}}

--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,12 @@
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "2.0.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
+    "ember-qunit": "0.4.15",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^2.1.4",
     "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0"
+    "qunit": "~1.20.0"
   },
   "devDependencies": {
     "blanket": "~1.1.5"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-hash-helper-polyfill": "0.1.0",
     "ember-wormhole": "0.3.4"
   },
   "ember-addon": {

--- a/tests/integration/components/ember-basic-dropdown-test.js
+++ b/tests/integration/components/ember-basic-dropdown-test.js
@@ -128,7 +128,7 @@ test('It can receive an onKeyDown action that is fired when a key is pressed whi
   `);
 
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
-  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(65));
+  Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 65));
 });
 
 test('Pressing Enter while the trigger is focused show the content', function(assert) {
@@ -147,7 +147,7 @@ test('Pressing Enter while the trigger is focused show the content', function(as
 
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(13));
+  Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 13));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
 });
 
@@ -168,7 +168,7 @@ test('Pressing Enter while the trigger is focused doesn\'t show the content if t
 
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(13));
+  Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 13));
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is still not rendered');
 });
 
@@ -189,7 +189,7 @@ test('Pressing ESC while the trigger is focused and the dropdown is opened', fun
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is rendered');
-  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(27));
+  Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 27));
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
 });
 
@@ -211,7 +211,7 @@ test('Pressing ESC while the trigger is focused and the dropdown is opened doesn
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is rendered');
-  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(27));
+  Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 27));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is still rendered');
 });
 
@@ -234,29 +234,18 @@ test('It yields an object with a toggle action that can be used from within the 
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
 });
 
-function createEventDispatcher(domElement) {
-  const Podium = {};
-  Podium.keydown = function(k) {
-    var oEvent = document.createEvent('KeyboardEvent');
+function triggerKeydown(domElement, k) {
+  var oEvent = document.createEvent("Events");
+  oEvent.initEvent('keydown', true, true);
+  $.extend(oEvent, {
+    view: window,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    keyCode: k,
+    charCode: k
+  });
 
-    // Chromium Hack
-    Object.defineProperty(oEvent, 'keyCode', {
-      get() { return this.keyCodeVal; }
-    });
-    Object.defineProperty(oEvent, 'which', {
-      get() {
-          return this.keyCodeVal;
-      }
-    });
-
-    if (oEvent.initKeyboardEvent) {
-      oEvent.initKeyboardEvent("keydown", true, true, document.defaultView, false, false, false, false, k, k);
-    } else {
-      oEvent.initKeyEvent("keydown", true, true, document.defaultView, false, false, false, false, k, 0);
-    }
-
-    oEvent.keyCodeVal = k;
-    domElement.dispatchEvent(oEvent);
-  };
-  return Podium;
+  domElement.dispatchEvent(oEvent);
 }

--- a/tests/integration/components/ember-basic-dropdown-test.js
+++ b/tests/integration/components/ember-basic-dropdown-test.js
@@ -31,7 +31,7 @@ test('It toggles when the trigger is clicked', function(assert) {
   `);
 
   assert.equal(this.$('.ember-basic-dropdown').length, 1, 'Is rendered');
-  assert.equal(this.$('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
@@ -111,11 +111,31 @@ test('It can receive an onFocus action that is fired when the trigger gets the f
 });
 
 test('It can receive an onKeyDown action that is fired when a key is pressed while the trigger is focused', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
-  this.didKeydown = function(e) {
+  this.didKeydown = function(publicAPI, e) {
     assert.ok(true, 'onKeydown action was invoked');
-    assert.equal(e.keyCode, 13, 'it receives the keydown event');
+    assert.equal(e.keyCode, 65, 'it receives the keydown event');
+    assert.ok(publicAPI.open && publicAPI.close && publicAPI.toggle, 'it receives an object with `open`, `close` and `toggle` functions');
+  };
+
+  this.render(hbs`
+    {{#ember-basic-dropdown onKeydown=didKeydown}}
+      <h3>Content of the dropdown</h3>
+    {{else}}
+      <button>Press me</button>
+    {{/ember-basic-dropdown}}
+  `);
+
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
+  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(65));
+});
+
+test('Pressing Enter while the trigger is focused show the content', function(assert) {
+  assert.expect(3);
+
+  this.didKeydown = function(/* publicAPI, e */) {
+    assert.ok(true, 'onKeydown action was invoked');
   };
   this.render(hbs`
     {{#ember-basic-dropdown onKeydown=didKeydown}}
@@ -126,30 +146,40 @@ test('It can receive an onKeyDown action that is fired when a key is pressed whi
   `);
 
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger($.Event('keydown', { keyCode: 13 })));
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
+  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(13));
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
 });
 
-test('It can be opened by firing a custom "dropdown:open" event', function(assert) {
-  assert.expect(2);
+test('Pressing Enter while the trigger is focused doesn\'t show the content if the event is default precented in the onKeydown action', function(assert) {
+  assert.expect(3);
 
+  this.didKeydown = function(publicAPI, e) {
+    assert.ok(true, 'onKeydown action was invoked');
+    e.preventDefault();
+  };
   this.render(hbs`
-    {{#ember-basic-dropdown}}
+    {{#ember-basic-dropdown onKeydown=didKeydown}}
       <h3>Content of the dropdown</h3>
     {{else}}
       <button>Press me</button>
     {{/ember-basic-dropdown}}
   `);
 
-  assert.equal(this.$('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => this.$('.ember-basic-dropdown')[0].dispatchEvent(new window.Event('dropdown:open')));
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
+  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(13));
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is still not rendered');
 });
 
-test('It can be closeed by firing a custom "dropdown:close" event', function(assert) {
-  assert.expect(2);
+test('Pressing ESC while the trigger is focused and the dropdown is opened', function(assert) {
+  assert.expect(3);
 
+  this.didKeydown = function(/* publicAPI, e */) {
+    assert.ok(true, 'onKeydown action was invoked');
+  };
   this.render(hbs`
-    {{#ember-basic-dropdown}}
+    {{#ember-basic-dropdown onKeydown=didKeydown}}
       <h3>Content of the dropdown</h3>
     {{else}}
       <button>Press me</button>
@@ -157,27 +187,32 @@ test('It can be closeed by firing a custom "dropdown:close" event', function(ass
   `);
 
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
-  Ember.run(() => this.$('.ember-basic-dropdown')[0].dispatchEvent(new window.Event('dropdown:close')));
-  assert.equal(this.$('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is rendered');
+  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(27));
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
 });
 
-test('It can be toggleed by firing a custom "dropdown:toggle" event', function(assert) {
+test('Pressing ESC while the trigger is focused and the dropdown is opened doesn\'t closes the dropdown if the event is defaultprevented', function(assert) {
   assert.expect(3);
 
+  this.didKeydown = function(publicAPI, e) {
+    assert.ok(true, 'onKeydown action was invoked');
+    e.preventDefault();
+  };
   this.render(hbs`
-    {{#ember-basic-dropdown}}
+    {{#ember-basic-dropdown onKeydown=didKeydown}}
       <h3>Content of the dropdown</h3>
     {{else}}
       <button>Press me</button>
     {{/ember-basic-dropdown}}
   `);
 
-  assert.equal(this.$('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => this.$('.ember-basic-dropdown')[0].dispatchEvent(new window.Event('dropdown:toggle')));
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
-  Ember.run(() => this.$('.ember-basic-dropdown')[0].dispatchEvent(new window.Event('dropdown:toggle')));
-  assert.equal(this.$('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is rendered');
+  Ember.run(() => createEventDispatcher(this.$('.ember-basic-dropdown-trigger')[0]).keydown(27));
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is still rendered');
 });
 
 test('It yields an object with a toggle action that can be used from within the content of the dropdown', function(assert) {
@@ -192,9 +227,36 @@ test('It yields an object with a toggle action that can be used from within the 
     {{/ember-basic-dropdown}}
   `);
 
-  assert.equal(this.$('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
   Ember.run(() => $('#click-to-close').click());
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
 });
+
+function createEventDispatcher(domElement) {
+  const Podium = {};
+  Podium.keydown = function(k) {
+    var oEvent = document.createEvent('KeyboardEvent');
+
+    // Chromium Hack
+    Object.defineProperty(oEvent, 'keyCode', {
+      get() { return this.keyCodeVal; }
+    });
+    Object.defineProperty(oEvent, 'which', {
+      get() {
+          return this.keyCodeVal;
+      }
+    });
+
+    if (oEvent.initKeyboardEvent) {
+      oEvent.initKeyboardEvent("keydown", true, true, document.defaultView, false, false, false, false, k, k);
+    } else {
+      oEvent.initKeyEvent("keydown", true, true, document.defaultView, false, false, false, false, k, 0);
+    }
+
+    oEvent.keyCodeVal = k;
+    domElement.dispatchEvent(oEvent);
+  };
+  return Podium;
+}


### PR DESCRIPTION
If the event sent to the outside gets defaultPrevented the default
behavior (toggle on enter, close on escape) won't execute.