### PR TITLE
Use getBoundingClientRect instead of outerWidth

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -109,8 +109,8 @@ export default Component.extend({
     const dropdown = this.appRoot.querySelector('.ember-basic-dropdown-content');
     if (this.get('matchTriggerWidth')) {
       const trigger = this.element.querySelector('.ember-basic-dropdown-trigger');
-      const clientWidth = trigger.clientWidth; // Don't include borders
-      dropdown.style.width = `${clientWidth}px`;
+      const triggerRect = trigger.getBoundingClientRect();
+      dropdown.style.width = `${triggerRect.width}px`;
     }
     let { left, top } = this.$().offset();
     if (dropdownPositionStrategy === 'above') {

--- a/app/styles/ember-basic-dropdown.scss
+++ b/app/styles/ember-basic-dropdown.scss
@@ -13,5 +13,4 @@ $ember-basic-dropdown-content-z-index: 1000 !default;
   width: auto;
   z-index: $ember-basic-dropdown-content-z-index;
   background-color: $ember-basic-dropdown-content-background-color;
-  box-sizing: content-box;
 }


### PR DESCRIPTION
It turn out that the issues was not related with the boxing model or the border,
it was related with pixel rounding. `offsetWidth` returns rounded pixels, which
in standard displays is ok but in retina ones might make a 1px difference.