### PR TITLE
Refactor yielded API

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -28,10 +28,12 @@ export default Component.extend({
     this._super(...arguments);
     const registerActionsInParent = this.get('registerActionsInParent');
     this.set('publicAPI', {
-      open: this.open.bind(this),
-      close: this.close.bind(this),
-      toggle: this.toggle.bind(this),
-      isOpen: false
+      isOpen: false,
+      actions: {
+        open: this.open.bind(this),
+        close: this.close.bind(this),
+        toggle: this.toggle.bind(this),
+      }
     });
     if (registerActionsInParent) {
       registerActionsInParent(this.get('publicAPI'));

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -118,7 +118,7 @@ test('It can receive an onKeyDown action that is fired when a key is pressed whi
   this.didKeydown = function(publicAPI, e) {
     assert.ok(true, 'onKeydown action was invoked');
     assert.equal(e.keyCode, 65, 'it receives the keydown event');
-    assert.ok(publicAPI.open && publicAPI.close && publicAPI.toggle, 'it receives an object with `open`, `close` and `toggle` functions');
+    assert.ok(publicAPI.actions.open && publicAPI.actions.close && publicAPI.actions.toggle, 'it receives an object with `open`, `close` and `toggle` functions');
   };
 
   this.render(hbs`
@@ -223,7 +223,7 @@ test('It yields an object with a toggle action that can be used from within the 
   this.render(hbs`
     {{#basic-dropdown as |dropdown|}}
       <h3>Content of the dropdown</h3>
-      <span id="click-to-close" onclick={{dropdown.toggle}}></span>
+      <span id="click-to-close" onclick={{dropdown.actions.toggle}}></span>
     {{else}}
       <button>Press me</button>
     {{/basic-dropdown}}


### PR DESCRIPTION
Now the yielded object has this form:
```js
{
  isOpened: <boolean>,
  actions: {
    open: fn<evt>,
    close: fn<evt>,
    toggle: fn<evt>
  }
}
```