### PR TITLE
Allowing to open close component passing `opened=true/false`

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -23,11 +23,6 @@ export default Component.extend({
     this.handleRootClick = this.handleRootClick.bind(this);
     this.handleRepositioningEvent = this.handleRepositioningEvent.bind(this);
     this.repositionDropdown = this.repositionDropdown.bind(this);
-  },
-
-  didInitAttrs() {
-    this._super(...arguments);
-    const registerActionsInParent = this.get('registerActionsInParent');
     this.set('publicAPI', {
       isOpen: false,
       actions: {
@@ -36,6 +31,11 @@ export default Component.extend({
         toggle: this.toggle.bind(this),
       }
     });
+  },
+
+  didInitAttrs() {
+    this._super(...arguments);
+    const registerActionsInParent = this.get('registerActionsInParent');
     if (registerActionsInParent) {
       registerActionsInParent(this.get('publicAPI'));
     }
@@ -43,14 +43,13 @@ export default Component.extend({
 
   didReceiveAttrs({ oldAttrs, newAttrs }) {
     this._super(...arguments);
-    let oldOpened = (oldAttrs || false) && (oldAttrs.opened || false) && (oldAttrs.opened.value || oldAttrs.opened || false);
-    let newOpened = (newAttrs || false) && (newAttrs.opened || false) && (newAttrs.opened.value || newAttrs.opened || false);
+    let oldOpened = (oldAttrs || false) && (oldAttrs.opened || false) && (oldAttrs.opened.value || false);
+    let newOpened = (newAttrs || false) && (newAttrs.opened || false) && (newAttrs.opened.value || false);
     if (!oldOpened && newOpened) {
       this.open();
-    } else if (oldOpened && !oldOpened) {
+    } else if (oldOpened && !newOpened) {
       this.close();
     }
-    // this.set('publicAPI.isOpen', this.get('opened') || false);
   },
 
   willDestroy() {
@@ -90,6 +89,7 @@ export default Component.extend({
 
   open(e) {
     if (this.get('disabled')) { return; }
+    this.set('opened', true);
     this.set('publicAPI.isOpen', true);
     this.addGlobalEvents();
     run.scheduleOnce('afterRender', this, this.repositionDropdown);
@@ -98,6 +98,7 @@ export default Component.extend({
   },
 
   close(e, skipFocus) {
+    this.set('opened', false);
     this.set('publicAPI.isOpen', false);
     this.set('_dropdownPositionClass', null);
     this.removeGlobalEvents();

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -41,6 +41,18 @@ export default Component.extend({
     }
   },
 
+  didReceiveAttrs({ oldAttrs, newAttrs }) {
+    this._super(...arguments);
+    let oldOpened = (oldAttrs || false) && (oldAttrs.opened || false) && (oldAttrs.opened.value || oldAttrs.opened || false);
+    let newOpened = (newAttrs || false) && (newAttrs.opened || false) && (newAttrs.opened.value || newAttrs.opened || false);
+    if (!oldOpened && newOpened) {
+      this.open();
+    } else if (oldOpened && !oldOpened) {
+      this.close();
+    }
+    // this.set('publicAPI.isOpen', this.get('opened') || false);
+  },
+
   willDestroy() {
     this._super(...arguments);
     this.removeGlobalEvents();

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -41,10 +41,10 @@ export default Component.extend({
     }
   },
 
-  didReceiveAttrs({ oldAttrs, newAttrs }) {
+  didReceiveAttrs({ oldAttrs }) {
     this._super(...arguments);
     let oldOpened = (oldAttrs || false) && (oldAttrs.opened || false) && (oldAttrs.opened.value || false);
-    let newOpened = (newAttrs || false) && (newAttrs.opened || false) && (newAttrs.opened.value || false);
+    let newOpened = this.get('opened') || false;
     if (!oldOpened && newOpened) {
       this.open();
     } else if (oldOpened && !newOpened) {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  showImage: true
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  showImage: true,
+
+  actions: {
+    toggleOpened() {
+      this.toggleProperty('opened');
+    }
+  }
+});

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   showImage: true,
+  opened: true,
 
   actions: {
     toggleOpened() {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -40,7 +40,7 @@
   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cum perferendis deserunt rerum minus? Cumque accusantium earum asperiores eos, ea autem. Earum consequatur dolores laborum ut, eaque ipsam sapiente, excepturi asperiores.
 </p>
 
-{{#basic-dropdown tabindex=-1 as |dropdown|}}
+{{#basic-dropdown opened=opened tabindex=-1 as |dropdown|}}
   <p>This is the content</p>
   <h3>It can contain anything.</h3>
   {{#if showImage}}
@@ -51,6 +51,8 @@
     This is the trigger
   </strong>
 {{/basic-dropdown}}
+
+<a href="#" {{action "toggleOpened"}}>Toggle the dropdown above</a>
 
 <p>
   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cum perferendis deserunt rerum minus? Cumque accusantium earum asperiores eos, ea autem. Earum consequatur dolores laborum ut, eaque ipsam sapiente, excepturi asperiores.

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -44,7 +44,7 @@
   <p>This is the content</p>
   <h3>It can contain anything.</h3>
   {{#if showImage}}
-    <img src="/grumpy-cat.png" alt="grumpy cat">
+    <img src="/grumpy-cat.png" alt="grumpy cat" width="300" height="300">
   {{/if}}
 {{else}}
   <strong tabindex="0">

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -291,6 +291,62 @@ test('It adds the proper class when a specific dropdown position is given', func
   assert.ok(this.$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--above'), 'The proper class has been added');
 });
 
+test('It can be rendered already when the `opened=true`', function(assert) {
+  assert.expect(1);
+
+  this.opened = true;
+  this.render(hbs`
+    {{#basic-dropdown opened=true}}
+      <h3>Content of the dropdown</h3>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
+});
+
+test('It opened and closed by toggling the property passed to `opened`', function(assert) {
+  assert.expect(3);
+
+  this.opened = false;
+  this.render(hbs`
+    {{#basic-dropdown opened=opened}}
+      <h3>Content of the dropdown</h3>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is closed');
+  Ember.run(() => this.set('opened', true));
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
+  Ember.run(() => this.set('opened', false));
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is again');
+});
+
+test('When the dropdown is opened and closed normally and the passed `opened` property is mutable, it gets mutated too', function(assert) {
+  assert.expect(5);
+
+  this.opened = false;
+  this.render(hbs`
+    {{#basic-dropdown opened=opened}}
+      <h3>Content of the dropdown</h3>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is closed');
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
+  assert.ok(this.get('opened'), 'The local property has been updated');
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is again');
+  assert.ok(!this.get('opened'), 'The local property has been updated again');
+});
+
+
 function triggerKeydown(domElement, k) {
   var oEvent = document.createEvent("Events");
   oEvent.initEvent('keydown', true, true);


### PR DESCRIPTION
This finally allows to pass the component a property to remotely control the component. 

When the property passes from falsey to truthy the component opens, and when goes to falsey it closes.

It is absolutely equivalent to open/close the component manually (the onOpen/onClose actions are invoked if provided), but at least for render the component already opened it avoids a repaint (render it closed and then re-render it opened)
