### PR TITLE
Refactor open/close into CP instead of didReceiveAttrs

### DIFF
--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -1,7 +1,7 @@
 <div class="ember-basic-dropdown-trigger {{triggerClass}}" tabindex={{tabIndex}} onkeydown={{action "keydown"}} onclick={{action "toggle"}} onfocus={{action "focusTrigger"}}>
   {{yield to="inverse"}}
 </div>
-{{#if publicAPI.isOpen}}
+{{#if opened}}
   {{#ember-wormhole to=_wormholeDestination renderInPlace=renderInPlace}}
     <div class="ember-basic-dropdown-content {{dropdownClass}} {{_dropdownPositionClass}}" dir={{dir}}>
       {{yield publicAPI}}


### PR DESCRIPTION
After some thought, this implementation seemed more efficient to me,
since it only does work when the received attribute is the `opened`
one, and the `publicAPI` is a computed property, meaning that is initialized
lazily and the all functions are reused.