### PR TITLE
Open/close dropdown on mousedown instead of on click

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -20,7 +20,7 @@ export default Component.extend({
     this._super(...arguments);
     const rootSelector = Ember.testing ? '#ember-testing' : getOwner(this).lookup('application:main').rootElement;
     this.appRoot = document.querySelector(rootSelector);
-    this.handleRootClick = this.handleRootClick.bind(this);
+    this.handleRootMouseDown = this.handleRootMouseDown.bind(this);
     this.handleRepositioningEvent = this.handleRepositioningEvent.bind(this);
     this.repositionDropdown = this.repositionDropdown.bind(this);
   },
@@ -131,7 +131,7 @@ export default Component.extend({
     run(this, this._runloopAwareRepositionDropdown);
   },
 
-  handleRootClick(e) {
+  handleRootMouseDown(e) {
     if (!this.element.contains(e.target) && !this.appRoot.querySelector('.ember-basic-dropdown-content').contains(e.target)) {
       this.close(e, true);
     }
@@ -142,7 +142,7 @@ export default Component.extend({
   },
 
   addGlobalEvents() {
-    this.appRoot.addEventListener('click', this.handleRootClick, true);
+    this.appRoot.addEventListener('mousedown', this.handleRootMouseDown, true);
     window.addEventListener('scroll', this.handleRepositioningEvent);
     window.addEventListener('resize', this.handleRepositioningEvent);
     window.addEventListener('orientationchange', this.handleRepositioningEvent);
@@ -166,7 +166,7 @@ export default Component.extend({
   },
 
   removeGlobalEvents() {
-    this.appRoot.removeEventListener('click', this.handleRootClick, true);
+    this.appRoot.removeEventListener('mousedown', this.handleRootMouseDown, true);
     window.removeEventListener('scroll', this.handleRepositioningEvent);
     window.removeEventListener('resize', this.handleRepositioningEvent);
     window.removeEventListener('orientationchange', this.handleRepositioningEvent);

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -1,4 +1,4 @@
-<div class="ember-basic-dropdown-trigger {{triggerClass}}" tabindex={{tabIndex}} onkeydown={{action "keydown"}} onclick={{action "toggle"}} onfocus={{action "focusTrigger"}}>
+<div class="ember-basic-dropdown-trigger {{triggerClass}}" tabindex={{tabIndex}} onkeydown={{action "keydown"}} onmousedown={{action "toggle"}} onfocus={{action "focusTrigger"}}>
   {{yield to="inverse"}}
 </div>
 {{#if opened}}

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -35,9 +35,9 @@ test('It toggles when the trigger is clicked and focuses the trigger', function(
 
   assert.equal(this.$('.ember-basic-dropdown').length, 1, 'Is rendered');
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
   assert.equal(this.$('.ember-basic-dropdown-trigger')[0], document.activeElement, 'The trigger is focused');
 });
@@ -54,9 +54,12 @@ test('It closes when you click outside the component and the trigger is not focu
     {{/basic-dropdown}}
   `);
 
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
-  Ember.run(() => this.$('#not-the-dropdown').click());
+  Ember.run(() => {
+    let event = new window.Event('mousedown');
+    this.$('#not-the-dropdown')[0].dispatchEvent(event);
+  });
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
   assert.notEqual(this.$('.ember-basic-dropdown-trigger')[0], document.activeElement, 'The trigger is not focused');
 });
@@ -78,7 +81,7 @@ test('It can receive an onOpen action that is fired when the component opens', f
     {{/basic-dropdown}}
   `);
 
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
 });
 
 test('It can receive an onClose action that is fired when the component closes', function(assert) {
@@ -98,8 +101,8 @@ test('It can receive an onClose action that is fired when the component closes',
     {{/basic-dropdown}}
   `);
 
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
 });
 
 test('It can receive an onFocus action that is fired when the trigger gets the focus', function(assert) {
@@ -200,7 +203,7 @@ test('Pressing ESC while the trigger is focused and the dropdown is opened', fun
     {{/basic-dropdown}}
   `);
 
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is rendered');
   Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 27));
@@ -222,7 +225,7 @@ test('Pressing ESC while the trigger is focused and the dropdown is opened doesn
     {{/basic-dropdown}}
   `);
 
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').focus());
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown is rendered');
   Ember.run(() => triggerKeydown(this.$('.ember-basic-dropdown-trigger')[0], 27));
@@ -242,7 +245,7 @@ test('It yields an object with a toggle action that can be used from within the 
   `);
 
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
   Ember.run(() => $('#click-to-close').click());
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
@@ -278,9 +281,9 @@ test('It toggles when the trigger is clicked BUT doesn\'t focus the trigger if i
 
   assert.equal(this.$('.ember-basic-dropdown').length, 1, 'Is rendered');
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown disappeared');
   assert.notEqual(this.$('.ember-basic-dropdown-trigger')[0], document.activeElement, 'The trigger is not focused');
 });
@@ -296,7 +299,7 @@ test('It adds the proper class when a specific dropdown position is given', func
     {{/basic-dropdown}}
   `);
 
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.ok(this.$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--above'), 'The proper class has been added');
 });
 
@@ -347,10 +350,10 @@ test('When the dropdown is opened and closed normally and the passed `opened` pr
   `);
 
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is closed');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
   assert.ok(this.get('opened'), 'The local property has been updated');
-  Ember.run(() => this.$('.ember-basic-dropdown-trigger').click());
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is again');
   assert.ok(!this.get('opened'), 'The local property has been updated again');
 });


### PR DESCRIPTION
Also the click on the root element to close the dropdown was replaced
by an mousedown event.

Reasoning:

- It is how real selects work.
- It feels snappy. Not having to wait for the mouseup makes the entire saves a few
  milliseconds (specially with trackpad) that make a difference.
- The mousedown is fired before the focus, so the onfocus event will be fired after.
  This is good because otherwise we can't tell wether the focus comes from a click
  or from navigating with tab key. Now we can tell because the mousedown happened
  just before.