### PR TITLE
Add horizontalPosition and verticalPosition options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ it based on the space around the trigger, and also will take care of reposition 
 resized, scrolled, the device changes it orientation or the content of the dropdown changes
 (implemented with MutationObservers in modern browsers with fallback to DOM events in IE 9/10).
 
-You can force the component to be fixed in one position by passing `dropdownPosition=above|below`.
+You can force the component to be fixed in one position by passing `verticalPosition = top | bottom` and/or `horizontalPosition = right | left`.
 
 #### Closed automatically when click outside the component
 

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -9,10 +9,11 @@ export default Component.extend({
   layout: layout,
   disabled: false,
   renderInPlace: false,
-  dropdownPosition: 'auto', // auto | above | below
+  verticalPosition: 'auto', // top | bottom
+  horizontalPosition: 'auto', // right | left
   classNames: ['ember-basic-dropdown'],
   attributeBindings: ['dir'],
-  classNameBindings: ['publicAPI.isOpen:ember-basic-dropdown--opened', 'disabled:ember-basic-dropdown--disabled', 'renderInPlace:ember-basic-dropdown--in-place', '_dropdownPositionClass'],
+  classNameBindings: ['publicAPI.isOpen:ember-basic-dropdown--opened', 'disabled:ember-basic-dropdown--disabled', 'renderInPlace:ember-basic-dropdown--in-place', '_verticalPositionClass', '_horizontalPositionClass'],
   _wormholeDestination: (Ember.testing ? 'ember-testing' : 'ember-basic-dropdown-wormhole'),
 
   // Lifecycle hooks
@@ -105,7 +106,8 @@ export default Component.extend({
   close(e, skipFocus) {
     if (!this.get('publicAPI.isOpen')) { return; }
     this.set('publicAPI.isOpen', false);
-    this.set('_dropdownPositionClass', null);
+    this.set('_verticalPositionClass', null);
+    this.set('_horizontalPositionClass', null);
     this.removeGlobalEvents();
     let onClose = this.get('onClose');
     if (onClose) { onClose(this.get('publicAPI'), e); }
@@ -186,37 +188,53 @@ export default Component.extend({
 
   _runloopAwareRepositionDropdown() {
     if (this.get('renderInPlace') || !this.get('publicAPI.isOpen')) { return; }
-    const dropdownPositionStrategy = this.get('dropdownPosition');
     const dropdown = this.appRoot.querySelector('.ember-basic-dropdown-content');
     const trigger = this.element.querySelector('.ember-basic-dropdown-trigger');
-    let { left, top: topWithoutScroll, width, height } = trigger.getBoundingClientRect();
+    let verticalPositionStrategy = this.get('verticalPosition');
+    let horizontalPositionStrategy = this.get('horizontalPosition');
+    let { left: triggerLeft, top: triggerTopWithoutScroll, width: triggerWidth, height: triggerHeight } = trigger.getBoundingClientRect();
+    let { width: dropdownWidth, height: dropdownHeight } = dropdown.getBoundingClientRect();
     let viewportTop  = Ember.$(window).scrollTop();
-    let top = topWithoutScroll + viewportTop;
+    let triggerTop = triggerTopWithoutScroll + viewportTop;
+    let top, left;
     if (this.get('matchTriggerWidth')) {
-      dropdown.style.width = `${width}px`;
+      dropdownWidth = triggerWidth;
+      dropdown.style.width = `${triggerWidth}px`;
     }
-    if (dropdownPositionStrategy === 'above') {
-      top = top - dropdown.getBoundingClientRect().height;
-      this.set('_dropdownPositionClass', 'ember-basic-dropdown--above');
-    } else if (dropdownPositionStrategy === 'below') {
-      top = top + height;
-      this.set('_dropdownPositionClass', 'ember-basic-dropdown--below');
-    } else { // auto
+
+    if(['top', 'bottom'].indexOf(verticalPositionStrategy) === -1) {
+      // vertical auto
       const viewportBottom = window.scrollY + window.innerHeight;
-      const dropdownHeight = dropdown.getBoundingClientRect().height;
-      const enoughRoomBelow = top + height + dropdownHeight < viewportBottom;
-      const enoughRoomAbove = topWithoutScroll > dropdownHeight;
-      let positionClass = this.get('_dropdownPositionClass');
-      if (positionClass === 'ember-basic-dropdown--below' && !enoughRoomBelow && enoughRoomAbove) {
-        this.set('_dropdownPositionClass', 'ember-basic-dropdown--above');
-      } else if (positionClass === 'ember-basic-dropdown--above' && !enoughRoomAbove && enoughRoomBelow) {
-        this.set('_dropdownPositionClass', 'ember-basic-dropdown--below');
-      } else if (!positionClass) {
-        this.set('_dropdownPositionClass', enoughRoomBelow ? 'ember-basic-dropdown--below' : 'ember-basic-dropdown--above');
-      }
-      positionClass = this.get('_dropdownPositionClass'); // It might have changed
-      top = top + (positionClass === 'ember-basic-dropdown--below' ? height : -dropdownHeight);
+      const roomForBottom = viewportBottom - triggerTop;
+      const roomForTop = triggerTopWithoutScroll;
+      verticalPositionStrategy = roomForTop > roomForBottom ? 'top' : 'bottom';
     }
+
+    if(['right', 'left'].indexOf(horizontalPositionStrategy) === -1) {
+      // horizontal auto
+      const viewportRight = window.scrollX + window.innerWidth;
+      const roomForRight = viewportRight - triggerLeft;
+      const roomForLeft = triggerLeft;
+
+      horizontalPositionStrategy = roomForRight > roomForLeft ? 'left' : 'right';
+    }
+
+    if (verticalPositionStrategy === 'top') {
+      top = triggerTop - dropdown.getBoundingClientRect().height;
+      this.set('_verticalPositionClass', 'ember-basic-dropdown--top');
+    } else {
+      top = triggerTop + triggerHeight;
+      this.set('_verticalPositionClass', 'ember-basic-dropdown--bottom');
+    }
+
+    if (horizontalPositionStrategy === 'right') {
+      left = triggerLeft + triggerWidth - dropdownWidth;
+      this.set('_horizontalPositionClass', 'ember-basic-dropdown--right');
+    } else {
+      left = triggerLeft;
+      this.set('_horizontalPositionClass', 'ember-basic-dropdown--left');
+    }
+
     dropdown.style.top = `${top}px`;
     dropdown.style.left = `${left}px`;
   }

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -196,7 +196,7 @@ export default Component.extend({
     let verticalPositionStrategy = this.get('verticalPosition');
     let horizontalPositionStrategy = this.get('horizontalPosition');
     let { left: triggerLeft, top: triggerTopWithoutScroll, width: triggerWidth, height: triggerHeight } = trigger.getBoundingClientRect();
-    let { width: dropdownWidth, height: dropdownHeight } = dropdown.getBoundingClientRect();
+    let { width: dropdownWidth } = dropdown.getBoundingClientRect();
     let viewportTop  = Ember.$(window).scrollTop();
     let triggerTop = triggerTopWithoutScroll + viewportTop;
     let top, left;

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -3,7 +3,7 @@
 </div>
 {{#if opened}}
   {{#ember-wormhole to=_wormholeDestination renderInPlace=renderInPlace}}
-    <div class="ember-basic-dropdown-content {{dropdownClass}} {{_dropdownPositionClass}}" dir={{dir}}>
+    <div class="ember-basic-dropdown-content {{dropdownClass}} {{_verticalPositionClass}} {{_horizontalPositionClass}}" dir={{dir}}>
       {{yield publicAPI}}
     </div>
   {{/ember-wormhole}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -68,7 +68,7 @@
       {{/if}}
     {{else}}
       <button>
-        Fixed with
+        Fixed width
       </button>
     {{/basic-dropdown}}
   </div>

--- a/tests/dummy/app/templates/opening-closing-order.hbs
+++ b/tests/dummy/app/templates/opening-closing-order.hbs
@@ -4,7 +4,7 @@
   <button>Press me 1</button>
 {{/basic-dropdown}}
 
-{{#basic-dropdown onOpen=(action "onOpenSecond") class="dd-2" dropdownPosition="above"}}
+{{#basic-dropdown onOpen=(action "onOpenSecond") class="dd-2" verticalPosition="top" horizontalPosition="left"}}
   <h3>Content of the dropdown 2</h3>
 {{else}}
   <button>Press me 2</button>

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -288,11 +288,11 @@ test('It toggles when the trigger is clicked BUT doesn\'t focus the trigger if i
   assert.notEqual(this.$('.ember-basic-dropdown-trigger')[0], document.activeElement, 'The trigger is not focused');
 });
 
-test('It adds the proper class when a specific dropdown position is given', function(assert) {
+test('It adds the proper class when a specific vertical position is given', function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    {{#basic-dropdown dropdownPosition="above"}}
+    {{#basic-dropdown verticalPosition="top"}}
       <h3>Content of the dropdown</h3>
     {{else}}
       <button>Press me</button>
@@ -300,8 +300,24 @@ test('It adds the proper class when a specific dropdown position is given', func
   `);
 
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
-  assert.ok(this.$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--above'), 'The proper class has been added');
+  assert.ok(this.$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--top'), 'The proper class has been added');
 });
+
+test('It adds the proper class when a specific horizontal position is given', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#basic-dropdown horizontalPosition="left"}}
+      <h3>Content of the dropdown</h3>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
+  assert.ok(this.$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--left'), 'The proper class has been added');
+});
+
 
 test('It can be rendered already when the `opened=true`', function(assert) {
   assert.expect(1);


### PR DESCRIPTION
### Feature: Horizontal Alignment 
- Add left, right or auto as new horizontal position options
- Add  top, bottom or auto as new vertical position options

You can force the component to be fixed in one position by passing `verticalPosition = top | bottom` and/or `horizontalPosition = right | left`.

### Examples
- `{{#basic-dropdown}}` // verticalPosition="auto" and horizontalPosition="auto"
- `{{#basic-dropdown verticalPosition="top"}}` //  horizontalPosition="auto"
- `{{#basic-dropdown horizontalPosition="left"}}` //  verticalPosition="auto"
- `{{#basic-dropdown verticalPosition="top" horizontalPosition="left"}}`

related: https://github.com/cibernox/ember-basic-dropdown/issues/29