### PR TITLE
when rendered in place don't handle root mouse click

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -133,8 +133,10 @@ export default Component.extend({
   },
 
   handleRootMouseDown(e) {
-    if (!this.element.contains(e.target) && !this.appRoot.querySelector('.ember-basic-dropdown-content').contains(e.target)) {
-      this.close(e, true);
+    if (!this.get('renderInPlace')) {
+      if (!this.element.contains(e.target) && !this.appRoot.querySelector('.ember-basic-dropdown-content').contains(e.target)) {
+        this.close(e, true);
+      }
     }
   },
 


### PR DESCRIPTION
Currently if renderInPlace is set to true no content is rendered into the wormhole so when the handler of route mouse down is fired it errors because .ember-basic-dropdown-content is not anywhere on the page.