### PR TITLE
Closing the dropdown cancels the pending times added when opening.

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -96,8 +96,8 @@ export default Component.extend({
     if (this.get('disabled') || this.get('publicAPI.isOpen')) { return; }
     if (e) { e.preventDefault(); }
     this.set('publicAPI.isOpen', true);
-    run.scheduleOnce('afterRender', this, this.addGlobalEvents);
-    run.scheduleOnce('afterRender', this, this.repositionDropdown);
+    this.addGlobalEventsTimer = run.scheduleOnce('afterRender', this, this.addGlobalEvents);
+    this.repositionDropdownTimer = run.scheduleOnce('afterRender', this, this.repositionDropdown);
     let onOpen = this.get('onOpen');
     if (onOpen) { onOpen(this.get('publicAPI'), e); }
   },
@@ -106,6 +106,9 @@ export default Component.extend({
     if (!this.get('publicAPI.isOpen')) { return; }
     this.set('publicAPI.isOpen', false);
     this.set('_dropdownPositionClass', null);
+    run.cancel(this.addGlobalEventsTimer);
+    run.cancel(this.repositionDropdownTimer);
+    this.addGlobalEventsTimer = this.repositionDropdownTimer = null;
     this.removeGlobalEvents();
     let onClose = this.get('onClose');
     if (onClose) { onClose(this.get('publicAPI'), e); }

--- a/tests/acceptance/open-and-immediatly-close-test.js
+++ b/tests/acceptance/open-and-immediatly-close-test.js
@@ -1,0 +1,21 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | Opening and immediatly close');
+
+test('BUGFIX: Opening and immediatly closing the component doesn\' leaves global event handlers', function(assert) {
+  assert.expect(0);
+  // This test has no assertion because the fact that runs without raising any exception
+  // is already the validation that works.
+
+  visit('/open-and-immediatly-close');
+
+  andThen(() => {
+    click('.ember-basic-dropdown-trigger');
+  });
+
+  andThen(() => {
+    let event = new window.Event('mousedown');
+    $('#other-div')[0].dispatchEvent(event);
+  });
+});

--- a/tests/dummy/app/controllers/open-and-immediatly-close.js
+++ b/tests/dummy/app/controllers/open-and-immediatly-close.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    immediatlyClose(dropdown) {
+      dropdown.actions.close();
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('runloop');
   this.route('opening-closing-order');
+  this.route('open-and-immediatly-close');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/open-and-immediatly-close.hbs
+++ b/tests/dummy/app/templates/open-and-immediatly-close.hbs
@@ -1,0 +1,7 @@
+{{#basic-dropdown onOpen=(action "immediatlyClose")}}
+  <h3>Content of the dropdown 1</h3>
+{{else}}
+  <button>Press me</button>
+{{/basic-dropdown}}
+
+<div id="other-div">Other content</div>


### PR DESCRIPTION
This prevents an exception to be raised when the dropdown is opened and
immediately closed, leading to event handlers in the root of the app 
that are never cleared.