### PR TITLE
Implement all role & aria properties in RFC

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -9,6 +9,7 @@ export default Component.extend({
   layout: layout,
   disabled: false,
   renderInPlace: false,
+  role: 'button',
   verticalPosition: 'auto', // above | below
   horizontalPosition: 'auto', // right | left
   classNames: ['ember-basic-dropdown'],

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -2,10 +2,11 @@
     id={{triggerId}}
     tabindex={{tabIndex}}
     role={{role}}
-    aria-expanded={{publicAPI.isOpen}}
     aria-disabled={{disabled}}
+    aria-expanded={{publicAPI.isOpen}}
+    aria-pressed={{publicAPI.isOpen}}
     aria-haspopup="true"
-    aria-owns={{dropdownId}}
+    aria-controls={{dropdownId}}
     aria-labelledby={{ariaLabelledBy}}
     aria-describedby={{ariaDescribedBy}}
     aria-required={{ariaRequired}}

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -448,12 +448,14 @@ test('It has a aria-haspopup property', function(assert) {
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-haspopup'), 'true');
 });
 
-test('It has `aria-expanded=true` when it is open', function(assert) {
-  assert.expect(2);
+test('It has `aria-expanded=true` and `aria-pressed=true` when it is open', function(assert) {
+  assert.expect(4);
   this.render(hbs`{{#basic-dropdown}} {{else}} {{/basic-dropdown}}`);
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-expanded'), 'false');
+  assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-pressed'), 'false');
   Ember.run(() => this.$('.ember-basic-dropdown-trigger').trigger('mousedown'));
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-expanded'), 'true');
+  assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-pressed'), 'true');
 });
 
 test('It supports setting the aria-invalid property', function(assert) {
@@ -462,9 +464,13 @@ test('It supports setting the aria-invalid property', function(assert) {
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-invalid'), 'true');
 });
 
+test('The default role of the trigger is button', function(assert) {
+  this.render(hbs`{{#basic-dropdown}} {{else}} {{/basic-dropdown}}`);
+  assert.equal(this.$('.ember-basic-dropdown-trigger').attr('role'), 'button');
+});
+
 test('It supports setting the role property', function(assert) {
-  this.render(hbs`
-    {{#basic-dropdown role="listbox"}} {{else}} {{/basic-dropdown}}`);
+  this.render(hbs`{{#basic-dropdown role="listbox"}} {{else}} {{/basic-dropdown}}`);
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('role'), 'listbox');
 });
 
@@ -507,8 +513,7 @@ test('The trigger can be customized with custom id and class', function(assert) 
   assert.equal($trigger.attr('id'), 'foo-id', 'The trigger has the given id');
 });
 
-
-test('The content of the dropdown has a unique ID and the trigger has `aria-owns=that-id`', function(assert) {
+test('The content of the dropdown has a unique ID and the trigger has `aria-controls=that-id`', function(assert) {
   assert.expect(2);
 
   this.render(hbs`
@@ -523,7 +528,7 @@ test('The content of the dropdown has a unique ID and the trigger has `aria-owns
   let dropdownId = $('.ember-basic-dropdown-content').attr('id');
   assert.ok(dropdownId.match(/^ember-basic-dropdown-content-ember\d+$/), 'The dropdown has a unique id');
   let $trigger = this.$('.ember-basic-dropdown-trigger');
-  assert.equal($trigger.attr('aria-owns'), dropdownId, 'The trigger aria-owns=<id-of-the-dropdown-content>');
+  assert.equal($trigger.attr('aria-controls'), dropdownId, 'The trigger aria-owns=<id-of-the-dropdown-content>');
 });
 
 function triggerKeydown(domElement, k) {


### PR DESCRIPTION
See https://github.com/cibernox/ember-power-select/issues/293#issuecomment-181419090

 - [x] `role=button`
 - [x] `aria-haspopup=true` tells AT to treat the trigger as a host for conditional content
 - [x] `aria-expanded=true/false` tells AT that conditional content is expanded
 - [x] `aria-pressed=true/false` tells AT that the `button` is in a pressed or 'true' state (technically different from whether the conditional content is expanded, but in practice usually the same).
 - [x] `aria-controls=<id of dropdown>` is all we need since there is no requirement that the trigger element own or have a direct DOM relationship to the dropdown