### PR TITLE
Add FastClick compatibility

### DIFF
--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -13,6 +13,7 @@
     aria-invalid={{ariaInvalid}}
     onkeydown={{action "keydown"}}
     onmousedown={{action "handleMousedown"}}
+    onclick={{action "handleMousedown"}}
     onfocus={{action "handleFocus"}}>
   {{yield to="inverse"}}
 </div>


### PR DESCRIPTION
[FastClick](https://github.com/ftlabs/fastclick) does not seem to handle `"mousedown"` events properly. Adding the `"onclick"` event allows the add-on to be used on mobile devices in combination with [FastClick](https://github.com/ftlabs/fastclick).

I'm trying to get this fixed in [FastClick](https://github.com/ftlabs/fastclick) library, but the maintainer does not seem to be very active considering the many open issues / pull requests. For now this might be the best way to allow users to continue using this very cool add-on.

Partly solves issue #248 described in ember-power-select "Incompatibility with fastclick?".
https://github.com/cibernox/ember-power-select/issues/248

Example of the issue:
![demo](https://cloud.githubusercontent.com/assets/3015394/13551626/5bda8d86-e340-11e5-9dbe-74126d6f3983.gif)