### PR TITLE
Add event handlers for touch events.

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -6,10 +6,10 @@ import config from 'ember-get-config';
 const { Component, run, computed } = Ember;
 const MutObserver = self.window.MutationObserver || self.window.WebKitMutationObserver;
 const defaultDestination = config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole';
-const isTouchDevice = (!!self.window && 'ontouchstart' in window);
 
 export default Component.extend({
   layout: layout,
+  isTouchDevice: (!!self.window && 'ontouchstart' in self.window),
   disabled: false,
   renderInPlace: false,
   role: 'button',
@@ -40,7 +40,7 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
     let trigger = this.element.querySelector('.ember-basic-dropdown-trigger');
-    if (isTouchDevice) {
+    if (this.isTouchDevice) {
       trigger.addEventListener('touchstart', e => {
         this.get('appRoot').addEventListener('touchmove', this._touchMoveHandler);
       });

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -12,7 +12,6 @@
     aria-required={{ariaRequired}}
     aria-invalid={{ariaInvalid}}
     onkeydown={{action "keydown"}}
-    onmousedown={{action "handleMousedown"}}
     onfocus={{action "handleFocus"}}>
   {{yield to="inverse"}}
 </div>

--- a/test-support/helpers/ember-basic-dropdown.js
+++ b/test-support/helpers/ember-basic-dropdown.js
@@ -7,3 +7,16 @@ export function clickTrigger(scope, options = {}) {
   Object.keys(options).forEach(key => event[key] = options[key]);
   Ember.run(() => Ember.$(selector)[0].dispatchEvent(event));
 }
+
+export function tapTrigger(scope, options = {}) {
+  let selector = '.ember-basic-dropdown-trigger';
+  if (scope) {
+    selector = scope + ' ' + selector;
+  }
+  let touchStartEvent = new window.Event('touchstart', { bubbles: true, cancelable: true, view: window });
+  Object.keys(options).forEach(key => touchStartEvent[key] = options[key]);
+  Ember.run(() => Ember.$(selector)[0].dispatchEvent(touchStartEvent));
+  let touchEndEvent = new window.Event('touchend', { bubbles: true, cancelable: true, view: window });
+  Object.keys(options).forEach(key => touchEndEvent[key] = options[key]);
+  Ember.run(() => Ember.$(selector)[0].dispatchEvent(touchEndEvent));
+}

--- a/tests/acceptance/opening-closing-order-test.js
+++ b/tests/acceptance/opening-closing-order-test.js
@@ -16,6 +16,7 @@ test('when a dropdown is opened and another dropdown is clicked, the first one c
 
   andThen(() => {
     let calls = this.application.__container__.lookup('controller:opening-closing-order').calls;
+    // console.debug(calls);
     assert.equal(calls.length, 3);
     assert.equal(calls[0], 'open1');
     assert.equal(calls[1], 'close1');

--- a/tests/dummy/app/controllers/opening-closing-order.js
+++ b/tests/dummy/app/controllers/opening-closing-order.js
@@ -12,6 +12,7 @@ export default Ember.Controller.extend({
     },
 
     onCloseFirst() {
+      // debugger;
       this.calls.push('close1');
     },
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -53,6 +53,9 @@
 {{/basic-dropdown}}
 
 <div id="wormhole-target"></div>
+<br>
+<br>
+<br>
 <a href="#" {{action "toggleOpened"}}>Toggle the dropdown above</a>
 
 <p>


### PR DESCRIPTION
Just relying in synthetic mouse events to be fired by the browser when touch events are not handled is less than optimal, and caused problems with fastclick.

Now the dropdown is opened on `touchend` (unless the user scrolled since the `touchstart`). Effectively, it is opened/closed on `tap`.