### PR TITLE
Remove double binding functionality in the `opened` property.

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -14,6 +14,7 @@ export default Component.extend({
   renderInPlace: false,
   role: 'button',
   destination: null,
+  initiallyOpened: false,
   verticalPosition: 'auto', // above | below
   horizontalPosition: 'auto', // right | left
   classNames: ['ember-basic-dropdown'],
@@ -90,7 +91,7 @@ export default Component.extend({
 
   publicAPI: computed(function() {
     return {
-      isOpen: false,
+      isOpen: this.get('initiallyOpened'),
       actions: {
         open: this.open.bind(this),
         close: this.close.bind(this),
@@ -98,19 +99,6 @@ export default Component.extend({
         reposition: this.handleRepositioningEvent.bind(this)
       }
     };
-  }),
-
-  opened: computed('publicAPI.isOpen', {
-    get() { return this.get('publicAPI.isOpen'); },
-    set(_, newOpened) {
-      const oldOpened = this.get('publicAPI.isOpen');
-      if (!oldOpened && newOpened) {
-        this.open();
-      } else if (oldOpened && !newOpened) {
-        this.close();
-      }
-      return this.get('publicAPI.isOpen');
-    }
   }),
 
   // Actions
@@ -190,9 +178,9 @@ export default Component.extend({
   },
 
   handleRootMouseDown(e) {
-    const elementContainsTarget = this.element.contains(e.target);
-    const dropdownContainsTarget = self.document.getElementById(this.get('dropdownId')).contains(e.target);
-  
+    let elementContainsTarget = this.element.contains(e.target);
+    let dropdownContainsTarget = self.document.getElementById(this.get('dropdownId')).contains(e.target);
+
     if (!elementContainsTarget && !dropdownContainsTarget) {
       this.close(e, true);
     }

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -15,7 +15,7 @@
     onfocus={{action "handleFocus"}}>
   {{yield to="inverse"}}
 </div>
-{{#if opened}}
+{{#if publicAPI.isOpen}}
   {{#basic-dropdown/content
     to=wormholeDestination
     renderInPlace=renderInPlace

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -374,12 +374,11 @@ test('It adds the proper class when a specific horizontal position is given', fu
   assert.ok(this.$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--right'), 'The proper class has been added');
 });
 
-test('It can be rendered already when the `opened=true`', function(assert) {
+test('It can be rendered already opened when the `initiallyOpened=true`', function(assert) {
   assert.expect(1);
 
-  this.opened = true;
   this.render(hbs`
-    {{#basic-dropdown opened=true}}
+    {{#basic-dropdown initiallyOpened=true}}
       <h3>Content of the dropdown</h3>
     {{else}}
       <button>Press me</button>
@@ -387,46 +386,6 @@ test('It can be rendered already when the `opened=true`', function(assert) {
   `);
 
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
-});
-
-test('It opened and closed by toggling the property passed to `opened`', function(assert) {
-  assert.expect(3);
-
-  this.opened = false;
-  this.render(hbs`
-    {{#basic-dropdown opened=opened}}
-      <h3>Content of the dropdown</h3>
-    {{else}}
-      <button>Press me</button>
-    {{/basic-dropdown}}
-  `);
-
-  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is closed');
-  Ember.run(() => this.set('opened', true));
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
-  Ember.run(() => this.set('opened', false));
-  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is again');
-});
-
-test('When the dropdown is opened and closed normally and the passed `opened` property is mutable, it gets mutated too', function(assert) {
-  assert.expect(5);
-
-  this.opened = false;
-  this.render(hbs`
-    {{#basic-dropdown opened=opened}}
-      <h3>Content of the dropdown</h3>
-    {{else}}
-      <button>Press me</button>
-    {{/basic-dropdown}}
-  `);
-
-  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is closed');
-  clickTrigger();
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
-  assert.ok(this.get('opened'), 'The local property has been updated');
-  clickTrigger();
-  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is again');
-  assert.ok(!this.get('opened'), 'The local property has been updated again');
 });
 
 test('Calling the `open` method while the dropdown is already opened does not call `onOpen` action', function(assert) {


### PR DESCRIPTION
Having this field being a special case was the source of some bugs
that had to do with the way the bindings were propagated. Bad shit.

All the component followed a strict DDAU policy except this field,
so I've removed it. You can still pass `initiallyOpened=true` to
render a component already opened, but it won't be updated anymore.
Any reaction to when a component is opened/closed has to be done
with the `onOpen`/`onClose` actions.