### PR TITLE
[FEATURE] Add `ember-basic-dropdown--focus-inside` class when something inside is focused

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -16,11 +16,17 @@ export default Component.extend({
   destination: null,
   triggerDisabled: false,
   initiallyOpened: false,
+  hasFocusInside: false,
   verticalPosition: 'auto', // above | below
   horizontalPosition: 'auto', // right | left
   classNames: ['ember-basic-dropdown'],
   attributeBindings: ['dir'],
-  classNameBindings: ['renderInPlace:ember-basic-dropdown--in-place', '_verticalPositionClass', '_horizontalPositionClass'],
+  classNameBindings: [
+    'renderInPlace:ember-basic-dropdown--in-place',
+    'hasFocusInside:ember-basic-dropdown--focus-inside',
+    '_verticalPositionClass',
+    '_horizontalPositionClass'
+  ],
 
   // Lifecycle hooks
   init() {
@@ -71,6 +77,15 @@ export default Component.extend({
       this.removeGlobalEvents();
     }
     this.get('appRoot').removeEventListener('touchmove', this._touchMoveHandler);
+  },
+
+  // Events
+  focusIn(e) {
+    this.send('handleFocusIn', e);
+  },
+
+  focusOut(e) {
+    this.send('handleFocusOut', e);
   },
 
   // CPs
@@ -126,7 +141,15 @@ export default Component.extend({
     handleFocus(e) {
       let onFocus = this.get('onFocus');
       if (onFocus) { onFocus(this.get('publicAPI'), e); }
-    }
+    },
+
+    handleFocusIn() {
+      this.set('hasFocusInside', true);
+    },
+
+    handleFocusOut() {
+      this.set('hasFocusInside', false);
+    },
   },
 
   // Methods

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -54,8 +54,8 @@ export default Component.extend({
         this.get('appRoot').addEventListener('touchmove', this._touchMoveHandler);
       });
       trigger.addEventListener('touchend', e => {
-        e.preventDefault(); // Prevent synthetic click
         this.send('handleTouchEnd', e)
+        e.preventDefault(); // Prevent synthetic click
       });
     }
     trigger.addEventListener('mousedown', e => this.send('handleMousedown', e));

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -35,6 +35,10 @@ export default WormholeComponent.extend({
   didInsertElement() {
     this._super(...arguments);
     let dropdown = self.window.document.getElementById(this.get('dropdownId'));
+    if (!this.get('renderInPlace')) {
+      dropdown.addEventListener('focusin', this.get('onFocusIn'));
+      dropdown.addEventListener('focusout', this.get('onFocusOut'));
+    }
     run.schedule('afterRender', this, function() {
       dropdown.classList.add('ember-basic-dropdown--transitioning-in');
       rAF(function() {
@@ -53,6 +57,9 @@ export default WormholeComponent.extend({
     let parentElement = dropdown.parentElement;
     if (this.get('renderInPlace')) {
       parentElement = parentElement.parentElement;
+    } else {
+      dropdown.removeEventListener('focusin', this.get('onFocusIn'));
+      dropdown.removeEventListener('focusout', this.get('onFocusOut'));
     }
     clone.id = clone.id + '--clone';
     run.schedule('afterRender', function() {

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -23,6 +23,8 @@
     dropdownClass=dropdownClass
     verticalPositionClass=_verticalPositionClass
     horizontalPositionClass=_horizontalPositionClass
+    onFocusIn=(action 'handleFocusIn')
+    onFocusOut=(action 'handleFocusOut')
     dir=dir}}
     {{yield publicAPI}}
   {{/basic-dropdown/content}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -46,10 +46,9 @@
   {{#if showImage}}
     <img src="/grumpy-cat.png" alt="grumpy cat" width="300" height="300">
   {{/if}}
+  <input type="text">
 {{else}}
-  <strong tabindex="0">
-    This is the trigger
-  </strong>
+  <input type="text" placeholder="Click me">
 {{/basic-dropdown}}
 
 <div id="wormhole-target"></div>

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -620,6 +620,60 @@ test('if the option `triggerDisabled` is set to true, the component won\'t respo
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is still not rendered');
 });
 
+test('when some element inside the trigger of a dropdown gains the focus, the dropdown obtains a `ember-basic-dropdown--focus-inside` class', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`
+    {{#basic-dropdown}}
+      <input type="text" id="input-inside-dropdown-content"/>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  assert.ok(!$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown doesn\'t have the focus-inside class yet');
+  clickTrigger();
+  assert.ok(!$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown doesn\'t have the focus-inside class yet');
+  Ember.run(() => this.$('button')[0].focus());
+  assert.ok($('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown has the focus-inside now');
+});
+
+test('when some element inside the dropdown-content when the component gets `renderedInPlace=true` gains the focus, the dropdown obtains a `ember-basic-dropdown--focus-inside` class', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`
+    {{#basic-dropdown renderedInPlace=true}}
+      <input type="text" id="input-inside-dropdown-content"/>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  assert.ok(!$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown doesn\'t have the focus-inside class yet');
+  clickTrigger();
+  assert.ok(!$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown doesn\'t have the focus-inside class yet');
+  Ember.run(() => $('#input-inside-dropdown-content')[0].focus());
+  assert.ok($('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown has the focus-inside now');
+});
+
+test('when some element inside the dropdown-content when the component gets `renderedInPlace=false` gains the focus, the dropdown obtains a `ember-basic-dropdown--focus-inside` class', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`
+    {{#basic-dropdown renderedInPlace=false}}
+      <input type="text" id="input-inside-dropdown-content"/>
+    {{else}}
+      <button>Press me</button>
+    {{/basic-dropdown}}
+  `);
+
+  assert.ok(!$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown doesn\'t have the focus-inside class yet');
+  clickTrigger();
+  assert.ok(!$('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown doesn\'t have the focus-inside class yet');
+  Ember.run(() => $('#input-inside-dropdown-content')[0].focus());
+  assert.ok($('.ember-basic-dropdown').hasClass('ember-basic-dropdown--focus-inside'), 'The dropdown has the focus-inside now');
+});
+
 // This is commented because this test fails in phantom, probably because of being an ancient version
 // of webkit.
 //


### PR DESCRIPTION
When any element inside the dropdown gets the focus, the entire dropdown gets a
`ember-basic-dropdown--focus-inside` class. That includes elements gaining the
focus inside the trigger or inside the dropdown, even if the dropdown is attached
somewhere else in the DOM tree.

When some element inside looses the focus, that class is removed.

This class is only added when the element gaining the focus is **inside** the dropdown,
not when the element is the dropdown itself has the focus.

Note: The trigger is considered to be a sub-component of the dropdown, and therefore
when the trigger is focused the class is added.

This feature is implemented using the `focusin`/`focusout` events. When the dropdown
is rendered in the root of the body, the component adds those events to the component
itself and to the dropdown-content, so it works as expected. When the dropdown is redered
"in place", it is smart enough to not add the events to the dropdown-content.

There is no default styles added to this class.