### PR TITLE
[BREAKING] onOpen and onClose now are called **before** opening/closing the component

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -157,17 +157,27 @@ export default Component.extend({
 
   open(e) {
     if (this.get('disabled') || this.get('publicAPI.isOpen')) { return; }
-    this.set('publicAPI.isOpen', true);
     let onOpen = this.get('onOpen');
-    if (onOpen) { onOpen(this.get('publicAPI'), e); }
+    if (onOpen) {
+      let returnValue = onOpen(this.get('publicAPI'), e);
+      if (returnValue === false || (e && e.defaultPrevented)) {
+        return;
+      }
+    }
+    this.set('publicAPI.isOpen', true);
   },
 
-  close(event, skipFocus) {
+  close(e, skipFocus) {
     if (!this.get('publicAPI.isOpen')) { return; }
+    let onClose = this.get('onClose');
+    if (onClose) {
+      let returnValue = onClose(this.get('publicAPI'), e);
+      if (returnValue === false || (e && e.defaultPrevented)) {
+        return;
+      }
+    }
     this.set('publicAPI.isOpen', false);
     this.setProperties({ _verticalPositionClass: null, _horizontalPositionClass: null });
-    let onClose = this.get('onClose');
-    if (onClose) { onClose(this.get('publicAPI'), event); }
     if (skipFocus) { return; }
     const trigger = this.element.querySelector('.ember-basic-dropdown-trigger');
     if (trigger.tabIndex > -1) {


### PR DESCRIPTION
This gives the change to the user to prevent the action either by returning false or
by calling `e.preventDefault` on the received event.

The breaking behaviour is that when the action is called, `dropdown.isOpen` has still the old value, as expected.

I don't nobody was relying on this.
