### PR TITLE
[BREAKING] Calling e.preventDefault on the event no changes the component's behavior

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -158,24 +158,14 @@ export default Component.extend({
   open(e) {
     if (this.get('disabled') || this.get('publicAPI.isOpen')) { return; }
     let onOpen = this.get('onOpen');
-    if (onOpen) {
-      let returnValue = onOpen(this.get('publicAPI'), e);
-      if (returnValue === false || (e && e.defaultPrevented)) {
-        return;
-      }
-    }
+    if (onOpen && onOpen(this.get('publicAPI'), e) === false) { return; }
     this.set('publicAPI.isOpen', true);
   },
 
   close(e, skipFocus) {
     if (!this.get('publicAPI.isOpen')) { return; }
     let onClose = this.get('onClose');
-    if (onClose) {
-      let returnValue = onClose(this.get('publicAPI'), e);
-      if (returnValue === false || (e && e.defaultPrevented)) {
-        return;
-      }
-    }
+    if (onClose && onClose(this.get('publicAPI'), e) === false) { return; }
     this.set('publicAPI.isOpen', false);
     this.setProperties({ _verticalPositionClass: null, _horizontalPositionClass: null });
     if (skipFocus) { return; }
@@ -188,9 +178,9 @@ export default Component.extend({
   handleKeydown(e) {
     if (this.get('disabled')) { return; }
     let onKeydown = this.get('onKeydown');
-    let returnVal;
-    if (onKeydown) { returnVal = onKeydown(this.get('publicAPI'), e); }
-    if (returnVal === false || e.defaultPrevented) { return; }
+    if (onKeydown && onKeydown(this.get('publicAPI'), e) === false) {
+      return;
+    }
     if (e.keyCode === 13) {  // Enter
       this.toggle(e);
     } else if (e.keyCode === 27) {

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -95,24 +95,6 @@ test('returning false from the `onOpen` action prevents the dropdown from openin
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is still closed');
 });
 
-test('calling `e.preventDefault()` on the event received by the `onOpen` action prevents the dropdown from opening', function(assert) {
-  assert.expect(1);
-
-  this.didOpen = function(dropdown, e) {
-    return e.preventDefault();
-  };
-  this.render(hbs`
-    {{#basic-dropdown onOpen=didOpen}}
-      <h3>Content of the dropdown</h3>
-    {{else}}
-      <button>Press me</button>
-    {{/basic-dropdown}}
-  `);
-
-  clickTrigger();
-  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is still closed');
-});
-
 test('It can receive an onClose action that is fired when the component closes', function(assert) {
   assert.expect(7);
 
@@ -157,28 +139,6 @@ test('returning false from the `onClose` action prevents the dropdown from closi
   clickTrigger();
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is still opened');
 });
-
-test('calling `e.preventDefault()` on the event received by the `onClose` action prevents the dropdown from closing', function(assert) {
-  assert.expect(3);
-
-  this.willClose = function(dropdown, e) {
-    return e.preventDefault();
-  };
-  this.render(hbs`
-    {{#basic-dropdown onClose=willClose}}
-      <h3>Content of the dropdown</h3>
-    {{else}}
-      <button>Press me</button>
-    {{/basic-dropdown}}
-  `);
-
-  assert.equal($('.ember-basic-dropdown-content').length, 0, 'The dropdown is closed');
-  clickTrigger();
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is opened');
-  clickTrigger();
-  assert.equal($('.ember-basic-dropdown-content').length, 1, 'The dropdown is still opened');
-});
-
 
 test('It can receive an onFocus action that is fired when the trigger gets the focus', function(assert) {
   var done = assert.async();
@@ -287,12 +247,12 @@ test('Pressing Enter while the trigger is focused show the content', function(as
   assert.equal($('.ember-basic-dropdown-content').length, 1, 'The content of the dropdown appeared');
 });
 
-test('Pressing Enter while the trigger is focused doesn\'t show the content if the event is default precented in the onKeydown action', function(assert) {
+test('Pressing Enter while the trigger is focused doesn\'t show the content if the onKeydown action returns false', function(assert) {
   assert.expect(3);
 
-  this.didKeydown = function(publicAPI, e) {
+  this.didKeydown = function() {
     assert.ok(true, 'onKeydown action was invoked');
-    e.preventDefault();
+    return false;
   };
   this.render(hbs`
     {{#basic-dropdown onKeydown=didKeydown}}
@@ -329,12 +289,12 @@ test('Pressing ESC while the trigger is focused and the dropdown is opened', fun
   assert.equal($('.ember-basic-dropdown-content').length, 0, 'The content of the dropdown is not rendered');
 });
 
-test('Pressing ESC while the trigger is focused and the dropdown is opened doesn\'t closes the dropdown if the event is defaultprevented', function(assert) {
+test('Pressing ESC while the trigger is focused and the dropdown is opened doesn\'t closes the dropdown the onKeydown action returns false', function(assert) {
   assert.expect(3);
 
-  this.didKeydown = function(publicAPI, e) {
+  this.didKeydown = function() {
     assert.ok(true, 'onKeydown action was invoked');
-    e.preventDefault();
+    return false;
   };
   this.render(hbs`
     {{#basic-dropdown onKeydown=didKeydown}}


### PR DESCRIPTION
After some experimentation, calling `e.preventDefault` was not a good idea. Calling it
on some events (keydown) by example will prevent other behaviour non related with this
component to work. And `return false` was already available.

Therefore, now return false is the new way to go to prevent the default behaviour
from happening.

The convention is:
- e.preventDefault will affect regular browser behaviour.
- return false will affect this component's behaviour only.