### PR TITLE
Fix horizontal position when using horizontal scroll

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -208,7 +208,8 @@ export default Component.extend({
       dropdownHeight, dropdownWidth,                        // dropdown dimensions
       scrollTop, scrollLeft                                 // scroll
     } = this._getPositionInfo(dropdown);
-    let dropdownTop, dropdownLeft = triggerLeft;
+    let triggerLeftWithScroll = triggerLeft + scrollLeft;
+    let dropdownTop, dropdownLeft = triggerLeftWithScroll;
 
     // hPosition
     let hPosition = this.get('horizontalPosition');
@@ -225,7 +226,7 @@ export default Component.extend({
         let roomForLeft = triggerLeft;
         hPosition = roomForRight > roomForLeft ? 'left' : 'right';
       }
-      if (hPosition === 'right') { dropdownLeft = triggerLeft + triggerWidth - dropdownWidth; }
+      if (hPosition === 'right') { dropdownLeft = triggerLeftWithScroll + triggerWidth - dropdownWidth; }
       this.set('_horizontalPositionClass', `ember-basic-dropdown--${hPosition}`);
     }
 


### PR DESCRIPTION
When using the dropdown on a page that is wider than 100% of the browser width, scrolling the page horizontal causes the position of the options to be incorrect.

The issue was caused by the left position of the box using just the output of getBoundingClientRect alone, which only accounts for the items position within the browser window and now within the document.
This had been resolved in the vertical scrolling by the addition of triggerTopWithScroll variable, so I have mimiced this with a triggerLeftWithScroll variable.

I think i've kept the logic that detect whether it should draw right or left the same, as I think this should work from the position in the browser and not the document, which is currently what it does.

Tested locally in my project and appears to work as expected.
Hope this helps this odd use case.
