### PR TITLE
Fix IE9 compatibility

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -64,11 +64,11 @@ export default WormholeComponent.extend({
     let parentElement = this.get('renderInPlace') ? dropdown.parentElement.parentElement : dropdown.parentElement;
     let clone = dropdown.cloneNode(true);
     clone.id = clone.id + '--clone';
-    parentElement.appendChild(clone);
-    let $clone = Ember.$('#' + parentElement.id + ' #' + clone.id);
+    let $clone = Ember.$(clone);
     $clone.removeClass('ember-basic-dropdown--transitioned-in');
     $clone.removeClass('ember-basic-dropdown--transitioning-in');
     $clone.addClass('ember-basic-dropdown--transitioning-out');
+    parentElement.appendChild(clone);
     waitForAnimations(clone, function() {
       parentElement.removeChild(clone);
     });

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -64,10 +64,11 @@ export default WormholeComponent.extend({
     let parentElement = this.get('renderInPlace') ? dropdown.parentElement.parentElement : dropdown.parentElement;
     let clone = dropdown.cloneNode(true);
     clone.id = clone.id + '--clone';
-    clone.classList.remove('ember-basic-dropdown--transitioned-in');
-    clone.classList.remove('ember-basic-dropdown--transitioning-in');
-    clone.classList.add('ember-basic-dropdown--transitioning-out');
     parentElement.appendChild(clone);
+    let $clone = Ember.$('#' + parentElement.id + ' #' + clone.id);
+    $clone.removeClass('ember-basic-dropdown--transitioned-in');
+    $clone.removeClass('ember-basic-dropdown--transitioning-in');
+    $clone.addClass('ember-basic-dropdown--transitioning-out');
     waitForAnimations(clone, function() {
       parentElement.removeChild(clone);
     });

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -6,7 +6,7 @@ const { run } = Ember;
 const MutObserver = self.window.MutationObserver || self.window.WebKitMutationObserver;
 function waitForAnimations(element, callback) {
   let computedStyle = self.window.getComputedStyle(element);
-  if (computedStyle.transitionDuration !== '0s') {
+  if (computedStyle.transitionDuration && computedStyle.transitionDuration !== '0s') {
     let eventCallback = function() {
       element.removeEventListener('transitionend', eventCallback);
       callback();


### PR DESCRIPTION
Currently the component is not working in IE9 due to two problems:

- IE9 does not implement 'classList', therefore adding and removing css-classes is not working. One solution is to use jQuery, another solution could be using a shim, see e.g. https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
- The 'getComputedStyle'-method does not consider 'transitionDuration' in IE9. Therefore 'transitionDuration' is undefined and a transition is always assumed.