### PR TITLE
Debug runloop problems

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -28,7 +28,6 @@ export default Component.extend({
         open: this.open.bind(this),
         close: this.close.bind(this),
         toggle: this.toggle.bind(this),
-        // reposition: () => run.join(this, this.reposition)
         reposition: () => run.join(this, this.reposition)
       }
     };
@@ -95,6 +94,10 @@ export default Component.extend({
   },
 
   reposition() {
+    run.scheduleOnce('afterRender', this, this.repositionNow);
+  },
+
+  repositionNow() {
     if (!this.publicAPI.isOpen) {
       return;
     }

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -4,6 +4,7 @@ import computed from 'ember-computed';
 import set, { setProperties } from  'ember-metal/set';
 import $ from 'jquery';
 import layout from '../templates/components/basic-dropdown';
+import run from 'ember-runloop';
 
 const { testing, getOwner } = Ember;
 
@@ -27,7 +28,8 @@ export default Component.extend({
         open: this.open.bind(this),
         close: this.close.bind(this),
         toggle: this.toggle.bind(this),
-        reposition: this.reposition.bind(this)
+        // reposition: () => run.join(this, this.reposition)
+        reposition: () => run.join(this, this.reposition)
       }
     };
 

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -71,7 +71,7 @@ export default Component.extend({
       if (!this.getAttr('renderInPlace')) {
         this.addGlobalEvents();
       }
-      run.scheduleOnce('actions', dropdown.actions.reposition);
+      dropdown.actions.reposition();
       if (this.get('animationEnabled')) {
         run.scheduleOnce('actions', this, this.animateIn, this.dropdownElement);
       }

--- a/index.js
+++ b/index.js
@@ -26,5 +26,7 @@ module.exports = {
         return '<div id="ember-basic-dropdown-wormhole"></div>';
       }
     }
-  }
+  },
+
+  isDevelopingAddon: function() { return true; }
 };

--- a/testem.js
+++ b/testem.js
@@ -7,7 +7,7 @@ module.exports = {
     "PhantomJS"
   ],
   "launch_in_dev": [
-    "PhantomJS",
+    // "PhantomJS",
     "Chrome"
   ]
 };

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import $ from 'jquery';


### PR DESCRIPTION
Problem to fix.

The `reposition` action sets some properties in the object, that are then propagated to other components. The problem is the reposition is invoked on a `didInsertElement` (because it needs to happen when the component is first opened) and also might be called at by a mutation observer callback and at user discretion.

All ideas I had either trigger a deprecation warning or break in testing mode.