### PR TITLE
[BUGFIX] Allow to pass `to=destination` when destination is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- [BUGFIX] Allow `to` property of the content component to be undefined
+
 # 0.12.0-beta.18
 - [BUGFIX] Fix positioning of dropdowns rendered in-place due to a typo
 

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -3,6 +3,7 @@ import layout from '../../templates/components/basic-dropdown/content';
 import config from 'ember-get-config';
 import $ from 'jquery';
 import Ember from 'ember';
+import fallbackIfUndefined from '../../utils/computed-fallback-if-undefined';
 import { join, scheduleOnce } from 'ember-runloop';
 
 const defaultDestination = config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole';
@@ -30,7 +31,7 @@ function waitForAnimations(element, callback) {
 export default Component.extend({
   layout,
   tagName: '',
-  to: testing ? 'ember-testing' : defaultDestination,
+  to: fallbackIfUndefined(testing ? 'ember-testing' : defaultDestination),
   animationEnabled: !testing,
   isTouchDevice: (!!self.window && 'ontouchstart' in self.window),
   hasMoved: false,


### PR DESCRIPTION
In that case the component will fallback to the default. It makes the component
easier to compose