### PR TITLE
Add fastboot-dist to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 /dist
 /tests
 /tmp
+/fastboot-dist
 **/.gitkeep
 .bowerrc
 .editorconfig


### PR DESCRIPTION
Its not alot of space but this reduces the install size by 2.7MB