### PR TITLE
Use requestAnimationFrame for animations

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -11,23 +11,29 @@ import { htmlSafe } from 'ember-string';
 const defaultDestination = config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole';
 const { testing } = Ember;
 const MutObserver = self.window.MutationObserver || self.window.WebKitMutationObserver;
+const rAF = self.window.requestAnimationFrame || function(cb) {
+  cb();
+};
+
 function waitForAnimations(element, callback) {
-  let computedStyle = self.window.getComputedStyle(element);
-  if (computedStyle.transitionDuration && computedStyle.transitionDuration !== '0s') {
-    let eventCallback = function() {
-      element.removeEventListener('transitionend', eventCallback);
+  rAF(function() {
+    let computedStyle = self.window.getComputedStyle(element);
+    if (computedStyle.transitionDuration && computedStyle.transitionDuration !== '0s') {
+      let eventCallback = function() {
+        element.removeEventListener('transitionend', eventCallback);
+        callback();
+      };
+      element.addEventListener('transitionend', eventCallback);
+    } else if (computedStyle.animationName !== 'none' && computedStyle.animationPlayState === 'running') {
+      let eventCallback = function() {
+        element.removeEventListener('animationend', eventCallback);
+        callback();
+      };
+      element.addEventListener('animationend', eventCallback);
+    } else {
       callback();
-    };
-    element.addEventListener('transitionend', eventCallback);
-  } else if (computedStyle.animationName !== 'none' && computedStyle.animationPlayState === 'running') {
-    let eventCallback = function() {
-      element.removeEventListener('animationend', eventCallback);
-      callback();
-    };
-    element.addEventListener('animationend', eventCallback);
-  } else {
-    callback();
-  }
+    }
+  });
 }
 
 export default Component.extend({

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-basic-dropdown",
   "dependencies": {
-    "ember": "~2.8.0-beta.1",
+    "ember": "~2.7.0",
     "ember-cli-shims": "0.1.3"
   }
 }


### PR DESCRIPTION
Trying the addon in glimmer made me realize the the current implementation was working just by chance, and that if Ember renders fast enough the styles would be calculated before the next frame and the animation wouldn't run.