### PR TITLE
Make the first reposition apply styles directly instead of using ember.

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -37,6 +37,10 @@ export default Component.extend({
   triggerComponent: fallbackIfUndefined('basic-dropdown/trigger'),
   contentComponent: fallbackIfUndefined('basic-dropdown/content'),
   classNames: ['ember-basic-dropdown'],
+  top: null,
+  left: null,
+  right: null,
+  width: null,
 
   // Lifecycle hooks
   init() {
@@ -117,7 +121,7 @@ export default Component.extend({
     if (onClose && onClose(publicAPI, e) === false) {
       return;
     }
-    this.setProperties({ hPosition: null, vPosition: null });
+    this.setProperties({ hPosition: null, vPosition: null, top: null, left: null, right: null, width: null });
     this.previousVerticalPosition = this.previousHorizontalPosition = null;
     this.updateState({ isOpen: false });
     if (skipFocus) {
@@ -241,6 +245,10 @@ export default Component.extend({
       changes.left = positions.style.left;
       changes.right = positions.style.right;
       changes.width = positions.style.width;
+      if (this.get('top') === null) {
+        // Bypass Ember on the first reposition only to avoid flickering.
+        $(dropdown).css(positions.style);
+      }
     }
     this.setProperties(changes);
     this.previousHorizontalPosition = positions.horizontalPosition;

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -84,8 +84,8 @@ export default Component.extend({
 
   // CPs
   style: computed('top', 'left', 'right', 'width', function() {
-    let { top, left, right, width } = this.getProperties('top', 'left', 'right', 'width');
     let style = '';
+    let { top, left, right, width } = this.getProperties('top', 'left', 'right', 'width');
     if (top) {
       style += `top: ${top};`;
     }

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -107,7 +107,7 @@
 
 <h4>Dropdown with an autofocused element inside</h4>
 <div style="margin: 80px">
-  {{#basic-dropdown renderInPlace=true as |dropdown|}}
+  {{#basic-dropdown as |dropdown|}}
     {{#dropdown.trigger tagName="button"}}Trigger of the first dropdown{{/dropdown.trigger}}
     {{#dropdown.content}}
       <p>content</p>


### PR DESCRIPTION
This only affects the first reposition. The reason is that if the dropdown contains an input
with autofocus and it gets the focus before it has been property positioned, the page scrolls
to the top (or bottom, depending where the wormhole placeholder is) to put that input into
the viewport.
There is no way for any component inside the dropdown to wait to get the focus (do it in the
afterRender is not enough), therefore this hack.
The style property is still bound in ember, and successive repositions will go through the usual
ember binding system.