### PR TITLE
Rename `dropdown._id` to `dropdown.uniqueId` and make it public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- [BREAKING] Rename the `dropdown._id` to `dropdown.uniqueId` and promote it to public API.
+
 # 0.13.0-beta.6
 - [BUGFIX] Make the first reposition faster by applying the styles directly instead of using bindings.
   This allows the dropdown to have components with autofocus inside without messing with the scroll.

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -53,7 +53,7 @@ export default Component.extend({
     instancesCounter++;
 
     let publicAPI = this.updateState({
-      _id: instancesCounter++,
+      uniqueId: instancesCounter++,
       isOpen: this.get('initiallyOpened') || false,
       disabled: this.get('disabled') || false,
       actions: {
@@ -64,8 +64,8 @@ export default Component.extend({
       }
     });
 
-    this.triggerId = this.triggerId || `ember-basic-dropdown-trigger-${publicAPI._id}`;
-    this.dropdownId = this.dropdownId || `ember-basic-dropdown-content-${publicAPI._id}`;
+    this.triggerId = this.triggerId || `ember-basic-dropdown-trigger-${publicAPI.uniqueId}`;
+    this.dropdownId = this.dropdownId || `ember-basic-dropdown-content-${publicAPI.uniqueId}`;
   },
 
   didReceiveAttrs() {

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -55,8 +55,8 @@ export default Component.extend({
     this.touchStartHandler = this.touchStartHandler.bind(this);
     this.touchMoveHandler = this.touchMoveHandler.bind(this);
     let dropdown = this.get('dropdown');
-    this.triggerId = `ember-basic-dropdown-trigger-${dropdown._id}`;
-    this.dropdownId = `ember-basic-dropdown-content-${dropdown._id}`;
+    this.triggerId = `ember-basic-dropdown-trigger-${dropdown.uniqueId}`;
+    this.dropdownId = `ember-basic-dropdown-content-${dropdown.uniqueId}`;
     if (this.get('animationEnabled')) {
       this.set('animationClass', this.get('transitioningInClass'));
     }

--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -42,8 +42,8 @@ export default Component.extend({
   init() {
     this._super(...arguments);
     let dropdown = this.get('dropdown');
-    this.elementId = `ember-basic-dropdown-trigger-${dropdown._id}`;
-    this.dropdownId = this.dropdownId || `ember-basic-dropdown-content-${dropdown._id}`;
+    this.elementId = `ember-basic-dropdown-trigger-${dropdown.uniqueId}`;
+    this.dropdownId = this.dropdownId || `ember-basic-dropdown-content-${dropdown.uniqueId}`;
     this._touchMoveHandler = this._touchMoveHandler.bind(this);
   },
 

--- a/tests/integration/components/basic-dropdown/content-test.js
+++ b/tests/integration/components/basic-dropdown/content-test.js
@@ -11,7 +11,7 @@ moduleForComponent('ember-basic-dropdown', 'Integration | Component | basic-drop
 test('If the dropdown is open renders the given block in a div with class `ember-basic-dropdown-content`', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -23,7 +23,7 @@ test('If the dropdown is open renders the given block in a div with class `ember
 test('If the dropdown is closed, nothing is rendered', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: false };
+  this.dropdown = { uniqueId: '123', isOpen: false };
   this.render(hbs`
     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -34,7 +34,7 @@ test('If the dropdown is closed, nothing is rendered', function(assert) {
 test('If it receives `renderInPlace=true`, it is rendered right here instead of elsewhere', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown renderInPlace=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -46,7 +46,7 @@ test('If it receives `renderInPlace=true`, it is rendered right here instead of 
 test('If it receives `to="foo123"`, it is rendered in the element with that ID', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     <div id="foo123"></div>
     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown to="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
@@ -56,10 +56,10 @@ test('If it receives `to="foo123"`, it is rendered in the element with that ID',
   assert.equal($content.parent()[0].id, 'foo123', 'It is rendered in the element with the given ID');
 });
 
-test('It derives the ID of the content from the `_id` property of of the dropdown', function(assert) {
+test('It derives the ID of the content from the `uniqueId` property of of the dropdown', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -70,7 +70,7 @@ test('It derives the ID of the content from the `_id` property of of the dropdow
 test('If it receives `class="foo123"`, the rendered content will have that class along with the default one', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown class="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -94,7 +94,7 @@ test('Clicking anywhere in the app outside the component will invoke the close a
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       close() {
@@ -118,7 +118,7 @@ test('Clicking anywhere inside the dropdown content doesn\'t invoke the close ac
   assert.expect(0);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       close() {
@@ -179,7 +179,7 @@ test('Tapping anywhere in the app outside the component will invoke the close ac
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       close() {
@@ -205,7 +205,7 @@ test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside 
   assert.expect(0);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       close() {
@@ -233,7 +233,7 @@ test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside 
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired inside the content', function(assert) {
   assert.expect(3);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.onFocusIn = (api, e) => {
     assert.ok(true, 'The action is invoked');
     assert.equal(api, this.dropdown, 'The first argument is the API');
@@ -251,7 +251,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
 test('If it receives an `onFocusOut` action, it is invoked if a focusout event is fired inside the content', function(assert) {
   assert.expect(3);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.onFocusOut = (api, e) => {
     assert.ok(true, 'The action is invoked');
     assert.equal(api, this.dropdown, 'The first argument is the API');
@@ -272,7 +272,7 @@ test('The component is repositioned immediatly when opened', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       reposition() {
@@ -289,7 +289,7 @@ test('The component is not repositioned if it is closed', function(assert) {
   assert.expect(0);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: false,
     actions: {
       reposition() {
@@ -307,7 +307,7 @@ test('The component is repositioned if the window scrolls', function(assert) {
   this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       reposition() {
@@ -327,7 +327,7 @@ test('The component is repositioned if the window is resized', function(assert) 
   this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       reposition() {
@@ -347,7 +347,7 @@ test('The component is repositioned if the orientation changes', function(assert
   this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       reposition() {
@@ -368,7 +368,7 @@ test('The component is repositioned if the content of the dropdown changs', func
   this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
-    _id: '123',
+    uniqueId: '123',
     isOpen: true,
     actions: {
       reposition() {

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -11,7 +11,7 @@ moduleForComponent('ember-basic-dropdown', 'Integration | Component | basic-drop
 test('It renders the given block in a div with class `ember-basic-dropdown-trigger`, with no wrapper around', function(assert) {
   assert.expect(3);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -26,7 +26,7 @@ test('It renders the given block in a div with class `ember-basic-dropdown-trigg
 test('If it doesn\'t receive any tabindex, the default is 0', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -38,7 +38,7 @@ test('If it doesn\'t receive any tabindex, the default is 0', function(assert) {
 test('If it receives a falsey tabindex, the default is 0', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot tabindex=null dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -50,7 +50,7 @@ test('If it receives a falsey tabindex, the default is 0', function(assert) {
 test('If it receives `tabindex=3`, the tabindex of the element is 3', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot tabindex=3 dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -62,7 +62,7 @@ test('If it receives `tabindex=3`, the tabindex of the element is 3', function(a
 test('If the dropdown is disabled, the tabindex is -1 regardless of if it has been customized or not', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123, disabled: true };
+  this.dropdown = { uniqueId: 123, disabled: true };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown tabindex=3}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -74,7 +74,7 @@ test('If the dropdown is disabled, the tabindex is -1 regardless of if it has be
 test('If it belongs to a disabled dropdown, it gets an `aria-disabled=true` attribute for a11y', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123, disabled: true };
+  this.dropdown = { uniqueId: 123, disabled: true };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -88,7 +88,7 @@ test('If it belongs to a disabled dropdown, it gets an `aria-disabled=true` attr
 test('If it receives `ariaLabel="foo123"` it gets an `aria-label="foo123"` attribute', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot ariaLabel="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -98,7 +98,7 @@ test('If it receives `ariaLabel="foo123"` it gets an `aria-label="foo123"` attri
 test('If it receives `ariaLabelledBy="foo123"` it gets an `aria-labelledby="foo123"` attribute', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot ariaLabelledBy="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -108,7 +108,7 @@ test('If it receives `ariaLabelledBy="foo123"` it gets an `aria-labelledby="foo1
 test('If it receives `ariaDescribedBy="foo123"` it gets an `aria-describedby="foo123"` attribute', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot ariaDescribedBy="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -118,7 +118,7 @@ test('If it receives `ariaDescribedBy="foo123"` it gets an `aria-describedby="fo
 test('If it receives `ariaRequired="true"` it gets an `aria-required="true"` attribute', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.required = true;
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot ariaRequired=required dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
@@ -133,7 +133,7 @@ test('If it receives `ariaInvalid="true"` it gets an `aria-invalid="true"` attri
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
   this.invalid = true;
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot ariaInvalid=invalid dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -146,7 +146,7 @@ test('If it receives `ariaInvalid="true"` it gets an `aria-invalid="true"` attri
 test('If the received dropdown is open, it has an `aria-expanded="true"` attribute', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123, isOpen: false };
+  this.dropdown = { uniqueId: 123, isOpen: false };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -159,7 +159,7 @@ test('If the received dropdown is open, it has an `aria-expanded="true"` attribu
 test('If the received dropdown is open, it has an `aria-pressed="true"` attribute', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123, isOpen: false };
+  this.dropdown = { uniqueId: 123, isOpen: false };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -172,7 +172,7 @@ test('If the received dropdown is open, it has an `aria-pressed="true"` attribut
 test('If it has an `aria-controls="foo123"` attribute pointing to the id of the content', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -183,7 +183,7 @@ test('If it has an `aria-controls="foo123"` attribute pointing to the id of the 
 test('If it receives `role="foo123"` it gets that attribute', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown role="foo123"}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -194,7 +194,7 @@ test('If it receives `role="foo123"` it gets that attribute', function(assert) {
 test('If it does not receive an specific `role`, the default is `button`', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -205,7 +205,7 @@ test('If it does not receive an specific `role`, the default is `button`', funct
 test('It has `aria-haspopup=true`', function(assert) {
   assert.expect(1);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -217,7 +217,7 @@ test('It has `aria-haspopup=true`', function(assert) {
 test('If it receives an `onMouseEnter` action, it will be invoked when a mouseenter event is received', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.onMouseEnter = (dropdown, e) => {
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
@@ -238,7 +238,7 @@ test('If it receives an `onMouseLeave` action, it will be invoked when a mousele
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onMouseLeave=onMouseLeave}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -255,7 +255,7 @@ test('If it receives an `onFocus` action, it will be invoked when it get focused
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onFocus=onFocus}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -269,7 +269,7 @@ test('If it receives an `onBlur` action, it will be invoked when it get blurred'
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onBlur=onBlur}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -285,7 +285,7 @@ test('If it receives an `onKeydown` action, it will be invoked when a key is pre
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
     assert.equal(e.keyCode, 70, 'the event is the keydown event');
   };
-  this.dropdown = { _id: 123 };
+  this.dropdown = { uniqueId: 123 };
   this.render(hbs`
     {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onKeydown=onKeydown}}Click me{{/basic-dropdown/trigger}}
   `);
@@ -297,7 +297,7 @@ test('Clicking invokes the `toggle` action on the dropdown', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     actions: {
       toggle(e) {
         assert.ok(true, 'The `toggle()` action has been fired');
@@ -315,7 +315,7 @@ test('Pressing ENTER fires the `toggle` action on the dropdown', function(assert
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     actions: {
       toggle(e) {
         assert.ok(true, 'The `toggle()` action has been fired');
@@ -334,7 +334,7 @@ test('Pressing SPACE fires the `toggle` action on the dropdown and preventsDefau
   assert.expect(3);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     actions: {
       toggle(e) {
         assert.ok(true, 'The `toggle()` action has been fired');
@@ -354,7 +354,7 @@ test('Pressing ESC fires the `close` action on the dropdown', function(assert) {
   assert.expect(2);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     actions: {
       close(e) {
         assert.ok(true, 'The `close()` action has been fired');
@@ -374,7 +374,7 @@ test('Pressing ENTER/SPACE/ESC does nothing of the onKeydown action returns fals
   this.appRoot = document.querySelector('#ember-testing');
   this.onKeydown = () => false;
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     actions: {
       close() {
         assert.ok(false, 'This action is not called');
@@ -398,7 +398,7 @@ test('Tapping invokes the toggle action on the dropdown', function(assert) {
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     actions: {
-      _id: 123,
+      uniqueId: 123,
       toggle(e) {
         assert.ok(true, 'The `toggle()` action has been fired');
         assert.ok(e instanceof window.Event && arguments.length === 1, 'It receives the event as first and only argument');
@@ -415,7 +415,7 @@ test('Firing a mousemove between a touchstart and a touchend (touch scroll) does
   assert.expect(0);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     actions: {
       toggle() {
         assert.ok(false, 'This action in not called');
@@ -435,7 +435,7 @@ test('If its dropdown is disabled it won\'t respond to mouse, touch or keyboard 
   assert.expect(0);
   this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
-    _id: 123,
+    uniqueId: 123,
     disabled: true,
     actions: {
       toggle() {
@@ -463,7 +463,7 @@ test('If its dropdown is disabled it won\'t respond to mouse, touch or keyboard 
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired on the trigger', function(assert) {
   assert.expect(3);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123, isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 123, isOpen: true, actions: { reposition() { } } };
   this.onFocusIn = (api, e) => {
     assert.ok(true, 'The action is invoked');
     assert.equal(api, this.dropdown, 'The first argument is the API');
@@ -481,7 +481,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired on the trigger', function(assert) {
   assert.expect(3);
   this.appRoot = document.querySelector('#ember-testing');
-  this.dropdown = { _id: 123, isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 123, isOpen: true, actions: { reposition() { } } };
   this.onFocusOut = (api, e) => {
     assert.ok(true, 'The action is invoked');
     assert.equal(api, this.dropdown, 'The first argument is the API');


### PR DESCRIPTION
This is breaking and would start the 0.14-beta.X series.