### PR TITLE
Stop caring about the app's root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- [BUGFIX] Consider the scope of the select the entire body, even if the app is rendered inside an
+  specific element.
+
 # 0.14.0-beta.0
 - [BREAKING] Rename the `dropdown._id` to `dropdown.uniqueId` and promote it to public API.
 

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -1,13 +1,10 @@
-import Ember from 'ember';
 import Component from 'ember-component';
-import computed from 'ember-computed';
 import set from  'ember-metal/set';
 import $ from 'jquery';
 import layout from '../templates/components/basic-dropdown';
 import { join } from 'ember-runloop';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 
-const { testing, getOwner } = Ember;
 const assign = Object.assign || function EmberAssign(original, ...args) {
   for (let i = 0; i < args.length; i++) {
     let arg = args[i];
@@ -79,15 +76,6 @@ export default Component.extend({
       join(this, this.enable);
     }
   },
-
-  // CPs
-  appRoot: computed(function() {
-    if (!self.document) {
-      return;
-    }
-    let rootSelector = testing ? '#ember-testing' : getOwner(this).lookup('application:main').rootElement;
-    return self.document.querySelector(rootSelector);
-  }),
 
   // Actions
   actions: {

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -106,13 +106,12 @@ export default Component.extend({
   // Methods
   open() {
     let dropdown = this.get('dropdown');
-    let appRoot = this.get('appRoot');
     this.triggerElement = this.triggerElement || document.getElementById(this.triggerId);
     this.dropdownElement = document.getElementById(this.dropdownId);
-    appRoot.addEventListener('mousedown', this.handleRootMouseDown, true);
+    self.document.body.addEventListener('mousedown', this.handleRootMouseDown, true);
     if (this.get('isTouchDevice')) {
-      appRoot.addEventListener('touchstart', this.touchStartHandler, true);
-      appRoot.addEventListener('touchend', this.handleRootMouseDown, true);
+      self.document.body.addEventListener('touchstart', this.touchStartHandler, true);
+      self.document.body.addEventListener('touchend', this.handleRootMouseDown, true);
     }
     let onFocusIn = this.get('onFocusIn');
     if (onFocusIn) {
@@ -214,21 +213,20 @@ export default Component.extend({
   },
 
   touchStartHandler() {
-    this.get('appRoot').addEventListener('touchmove', this.touchMoveHandler, true);
+    self.document.body.addEventListener('touchmove', this.touchMoveHandler, true);
   },
 
   touchMoveHandler() {
     this.hasMoved = true;
-    this.get('appRoot').removeEventListener('touchmove', this.touchMoveHandler, true);
+    self.document.body.removeEventListener('touchmove', this.touchMoveHandler, true);
   },
 
   _teardown() {
-    let appRoot = this.get('appRoot');
     this.removeGlobalEvents();
-    appRoot.removeEventListener('mousedown', this.handleRootMouseDown, true);
+    self.document.body.removeEventListener('mousedown', this.handleRootMouseDown, true);
     if (this.get('isTouchDevice')) {
-      appRoot.removeEventListener('touchstart', this.touchStartHandler, true);
-      appRoot.removeEventListener('touchend', this.handleRootMouseDown, true);
+      self.document.body.removeEventListener('touchstart', this.touchStartHandler, true);
+      self.document.body.removeEventListener('touchend', this.handleRootMouseDown, true);
     }
   }
 });

--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -55,7 +55,7 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
-    this.get('appRoot').removeEventListener('touchmove', this._touchMoveHandler);
+    self.document.body.removeEventListener('touchmove', this._touchMoveHandler);
   },
 
   // CPs
@@ -109,7 +109,7 @@ export default Component.extend({
         dropdown.actions.toggle(e);
       }
       this.hasMoved = false;
-      this.get('appRoot').removeEventListener('touchmove', this._touchMoveHandler);
+      self.document.body.removeEventListener('touchmove', this._touchMoveHandler);
     },
 
     handleKeydown(e) {
@@ -135,23 +135,23 @@ export default Component.extend({
   // Methods
   _touchMoveHandler() {
     this.hasMoved = true;
-    this.get('appRoot').removeEventListener('touchmove', this._touchMoveHandler);
+    self.document.body.removeEventListener('touchmove', this._touchMoveHandler);
   },
 
   stopTextSelectionUntilMouseup() {
-    let $appRoot = $(this.get('appRoot'));
+    let $body = $(self.document.body);
     let mouseupHandler = function() {
-      $appRoot[0].removeEventListener('mouseup', mouseupHandler, true);
-      $appRoot.removeClass('ember-basic-dropdown-text-select-disabled');
+      self.document.body.removeEventListener('mouseup', mouseupHandler, true);
+      $body.removeClass('ember-basic-dropdown-text-select-disabled');
     };
-    $appRoot[0].addEventListener('mouseup', mouseupHandler, true);
-    $appRoot.addClass('ember-basic-dropdown-text-select-disabled');
+    self.document.body.addEventListener('mouseup', mouseupHandler, true);
+    $body.addClass('ember-basic-dropdown-text-select-disabled');
   },
 
   addMandatoryHandlers() {
     if (this.get('isTouchDevice')) {
       this.element.addEventListener('touchstart', () => {
-        this.get('appRoot').addEventListener('touchmove', this._touchMoveHandler);
+        self.document.body.addEventListener('touchmove', this._touchMoveHandler);
       });
       this.element.addEventListener('touchend', (e) => {
         this.send('handleTouchEnd', e);

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -3,7 +3,6 @@
   disabled=publicAPI.disabled
   actions=publicAPI.actions
   trigger=(component triggerComponent
-    appRoot=(readonly appRoot)
     dropdown=(readonly publicAPI)
     hPosition=(readonly hPosition)
     onFocus=(action "handleFocus")
@@ -11,7 +10,6 @@
     vPosition=(readonly vPosition)
   )
   content=(component contentComponent
-    appRoot=(readonly appRoot)
     dropdown=(readonly publicAPI)
     hPosition=(readonly hPosition)
     renderInPlace=(readonly renderInPlace)

--- a/tests/integration/components/basic-dropdown/content-test.js
+++ b/tests/integration/components/basic-dropdown/content-test.js
@@ -10,10 +10,9 @@ moduleForComponent('ember-basic-dropdown', 'Integration | Component | basic-drop
 // Basic rendering
 test('If the dropdown is open renders the given block in a div with class `ember-basic-dropdown-content`', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = $('.ember-basic-dropdown-content');
   assert.equal($content.text().trim(), 'Lorem ipsum', 'It contains the given block');
@@ -22,10 +21,9 @@ test('If the dropdown is open renders the given block in a div with class `ember
 
 test('If the dropdown is closed, nothing is rendered', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: false };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = $('.ember-basic-dropdown-content');
   assert.equal($content.length, 0, 'Nothing is rendered');
@@ -33,10 +31,9 @@ test('If the dropdown is closed, nothing is rendered', function(assert) {
 
 test('If it receives `renderInPlace=true`, it is rendered right here instead of elsewhere', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown renderInPlace=true}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown renderInPlace=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = this.$('.ember-basic-dropdown-content');
   assert.equal($content.length, 1, 'It is rendered in the spot');
@@ -45,11 +42,10 @@ test('If it receives `renderInPlace=true`, it is rendered right here instead of 
 
 test('If it receives `to="foo123"`, it is rendered in the element with that ID', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     <div id="foo123"></div>
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown to="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown to="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = this.$('#foo123 .ember-basic-dropdown-content');
   assert.equal($content.length, 1, 'It is rendered');
@@ -58,10 +54,9 @@ test('If it receives `to="foo123"`, it is rendered in the element with that ID',
 
 test('It derives the ID of the content from the `uniqueId` property of of the dropdown', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = $('.ember-basic-dropdown-content');
   assert.equal($content.attr('id'), 'ember-basic-dropdown-content-123', 'contains the expected ID');
@@ -69,10 +64,9 @@ test('It derives the ID of the content from the `uniqueId` property of of the dr
 
 test('If it receives `class="foo123"`, the rendered content will have that class along with the default one', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown class="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown class="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = $('.ember-basic-dropdown-content.foo123');
   assert.equal($content.length, 1, 'The dropdown contains that class');
@@ -80,10 +74,9 @@ test('If it receives `class="foo123"`, the rendered content will have that class
 
 test('If it receives `dir="rtl"`, the rendered content will have the attribute set', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown dir="rtl"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown dir="rtl"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = $('.ember-basic-dropdown-content');
   assert.equal($content.attr('dir'), 'rtl', 'The dropdown has `dir="rtl"`');
@@ -92,7 +85,6 @@ test('If it receives `dir="rtl"`, the rendered content will have the attribute s
 // Clicking while the component is opened
 test('Clicking anywhere in the app outside the component will invoke the close action on the dropdown', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: '123',
     isOpen: true,
@@ -105,7 +97,7 @@ test('Clicking anywhere in the app outside the component will invoke the close a
   };
   this.render(hbs`
     <div id="other-div"></div>
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 
   run(() => {
@@ -116,7 +108,6 @@ test('Clicking anywhere in the app outside the component will invoke the close a
 
 test('Clicking anywhere inside the dropdown content doesn\'t invoke the close action', function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: '123',
     isOpen: true,
@@ -128,7 +119,7 @@ test('Clicking anywhere inside the dropdown content doesn\'t invoke the close ac
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}<div id="inside-div">Lorem ipsum</div>{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}<div id="inside-div">Lorem ipsum</div>{{/basic-dropdown/content}}
   `);
 
   run(() => {
@@ -139,7 +130,6 @@ test('Clicking anywhere inside the dropdown content doesn\'t invoke the close ac
 
 test('Clicking in inside the a dropdown content nested inside another dropdown content doesn\'t invoke the close action on neither of them if the second is rendered in place' , function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown1 = {
     isOpen: true,
     actions: {
@@ -160,9 +150,9 @@ test('Clicking in inside the a dropdown content nested inside another dropdown c
   };
   this.render(hbs`
     <div id="fake-trigger"></div>
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown1}}
+    {{#basic-dropdown/content dropdown=dropdown1}}
       Lorem ipsum
-      {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown2 renderInPlace=true}}
+      {{#basic-dropdown/content dropdown=dropdown2 renderInPlace=true}}
         <div id="nested-content-div">dolor sit amet</div>
       {{/basic-dropdown/content}}
     {{/basic-dropdown/content}}
@@ -177,7 +167,6 @@ test('Clicking in inside the a dropdown content nested inside another dropdown c
 // Touch gestures while the component is opened
 test('Tapping anywhere in the app outside the component will invoke the close action on the dropdown', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: '123',
     isOpen: true,
@@ -190,7 +179,7 @@ test('Tapping anywhere in the app outside the component will invoke the close ac
   };
   this.render(hbs`
     <div id="other-div"></div>
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 
   run(() => {
@@ -203,7 +192,6 @@ test('Tapping anywhere in the app outside the component will invoke the close ac
 
 test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside the component will invoke the close action on the dropdown', function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: '123',
     isOpen: true,
@@ -216,7 +204,7 @@ test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside 
   };
   this.render(hbs`
     <div id="other-div"></div>
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 
   run(() => {
@@ -232,7 +220,6 @@ test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside 
 // Focus
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired inside the content', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.onFocusIn = (api, e) => {
     assert.ok(true, 'The action is invoked');
@@ -240,7 +227,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown onFocusIn=onFocusIn}}
+    {{#basic-dropdown/content dropdown=dropdown onFocusIn=onFocusIn}}
       <input type="text" id="test-input-focusin" />
     {{/basic-dropdown/content}}
   `);
@@ -250,7 +237,6 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
 
 test('If it receives an `onFocusOut` action, it is invoked if a focusout event is fired inside the content', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
   this.onFocusOut = (api, e) => {
     assert.ok(true, 'The action is invoked');
@@ -258,7 +244,7 @@ test('If it receives an `onFocusOut` action, it is invoked if a focusout event i
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown onFocusOut=onFocusOut}}
+    {{#basic-dropdown/content dropdown=dropdown onFocusOut=onFocusOut}}
       <input type="text" id="test-input-focusin" />
     {{/basic-dropdown/content}}
   `);
@@ -270,7 +256,6 @@ test('If it receives an `onFocusOut` action, it is invoked if a focusout event i
 // Repositining
 test('The component is repositioned immediatly when opened', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: '123',
     isOpen: true,
@@ -281,13 +266,12 @@ test('The component is repositioned immediatly when opened', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 });
 
 test('The component is not repositioned if it is closed', function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: '123',
     isOpen: false,
@@ -298,13 +282,12 @@ test('The component is not repositioned if it is closed', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 });
 
 test('The component is repositioned if the window scrolls', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
     uniqueId: '123',
@@ -316,7 +299,7 @@ test('The component is repositioned if the window scrolls', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   run(() => window.dispatchEvent(new window.Event('scroll')));
   assert.equal(repositions, 2, 'The component has been repositioned twice');
@@ -324,7 +307,6 @@ test('The component is repositioned if the window scrolls', function(assert) {
 
 test('The component is repositioned if the window is resized', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
     uniqueId: '123',
@@ -336,7 +318,7 @@ test('The component is repositioned if the window is resized', function(assert) 
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   run(() => window.dispatchEvent(new window.Event('resize')));
   assert.equal(repositions, 2, 'The component has been repositioned twice');
@@ -344,7 +326,6 @@ test('The component is repositioned if the window is resized', function(assert) 
 
 test('The component is repositioned if the orientation changes', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
     uniqueId: '123',
@@ -356,7 +337,7 @@ test('The component is repositioned if the orientation changes', function(assert
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   run(() => window.dispatchEvent(new window.Event('orientationchange')));
   assert.equal(repositions, 2, 'The component has been repositioned twice');
@@ -365,7 +346,6 @@ test('The component is repositioned if the orientation changes', function(assert
 test('The component is repositioned if the content of the dropdown changs', function(assert) {
   assert.expect(1);
   let done = assert.async();
-  this.appRoot = document.querySelector('#ember-testing');
   let repositions = 0;
   this.dropdown = {
     uniqueId: '123',
@@ -381,7 +361,7 @@ test('The component is repositioned if the content of the dropdown changs', func
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown}}
+    {{#basic-dropdown/content dropdown=dropdown}}
       <div id="content-target-div"></div>
     {{/basic-dropdown/content}}
   `);
@@ -396,7 +376,6 @@ test('The component is repositioned if the content of the dropdown changs', func
 // test('The component is opened with an `transitioning-in` class that is then replaced by a `transitioned-in` class once the animation finishes', function(assert) {
 //   assert.expect(3);
 //   let done = assert.async();
-//   this.appRoot = document.querySelector('#ember-testing');
 //   this.dropdown = { isOpen: true, actions: { reposition() { } } };
 //   this.render(hbs`
 //     <style>
@@ -409,7 +388,7 @@ test('The component is repositioned if the content of the dropdown changs', func
 //         animation: test-fade-in 0.25s;
 //       }
 //     </style>
-//     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown class="test-fade-in"}}Lorem ipsum{{/basic-dropdown/content}}
+//     {{#basic-dropdown/content dropdown=dropdown class="test-fade-in"}}Lorem ipsum{{/basic-dropdown/content}}
 //   `);
 //   let $content = $('.ember-basic-dropdown-content');
 //   assert.ok($content.hasClass('ember-basic-dropdown--transitioning-in'), 'Renders with a transitioning-in class');
@@ -423,7 +402,6 @@ test('The component is repositioned if the content of the dropdown changs', func
 // test('The component is closed by addong `transitioning-out` class to a ghost copy of the dropdown', function(assert) {
 //   assert.expect(2);
 //   let done = assert.async();
-//   this.appRoot = document.querySelector('#ember-testing');
 //   this.dropdown = { isOpen: true, actions: { reposition() { } } };
 //   this.render(hbs`
 //     <style>
@@ -436,7 +414,7 @@ test('The component is repositioned if the content of the dropdown changs', func
 //         animation: test-fade-in 0.25s reverse;
 //       }
 //     </style>
-//     {{#basic-dropdown/content appRoot=appRoot dropdown=dropdown class="test-fade-in"}}Lorem ipsum{{/basic-dropdown/content}}
+//     {{#basic-dropdown/content dropdown=dropdown class="test-fade-in"}}Lorem ipsum{{/basic-dropdown/content}}
 //   `);
 //   run(() => this.set('dropdown.isOpen', false));
 //   let $content = $('.ember-basic-dropdown-content');

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -10,10 +10,9 @@ moduleForComponent('ember-basic-dropdown', 'Integration | Component | basic-drop
 
 test('It renders the given block in a div with class `ember-basic-dropdown-trigger`, with no wrapper around', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   let $trigger = this.$('.ember-basic-dropdown-trigger');
@@ -25,10 +24,9 @@ test('It renders the given block in a div with class `ember-basic-dropdown-trigg
 // Attributes and a11y
 test('If it doesn\'t receive any tabindex, the default is 0', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   let $trigger = this.$('.ember-basic-dropdown-trigger');
@@ -37,10 +35,9 @@ test('If it doesn\'t receive any tabindex, the default is 0', function(assert) {
 
 test('If it receives a falsey tabindex, the default is 0', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot tabindex=null dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger tabindex=null dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   let $trigger = this.$('.ember-basic-dropdown-trigger');
@@ -49,10 +46,9 @@ test('If it receives a falsey tabindex, the default is 0', function(assert) {
 
 test('If it receives `tabindex=3`, the tabindex of the element is 3', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot tabindex=3 dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger tabindex=3 dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   let $trigger = this.$('.ember-basic-dropdown-trigger');
@@ -61,10 +57,9 @@ test('If it receives `tabindex=3`, the tabindex of the element is 3', function(a
 
 test('If the dropdown is disabled, the tabindex is -1 regardless of if it has been customized or not', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123, disabled: true };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown tabindex=3}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown tabindex=3}}Click me{{/basic-dropdown/trigger}}
   `);
 
   let $trigger = this.$('.ember-basic-dropdown-trigger');
@@ -73,10 +68,9 @@ test('If the dropdown is disabled, the tabindex is -1 regardless of if it has be
 
 test('If it belongs to a disabled dropdown, it gets an `aria-disabled=true` attribute for a11y', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123, disabled: true };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   let $trigger = this.$('.ember-basic-dropdown-trigger');
@@ -87,41 +81,37 @@ test('If it belongs to a disabled dropdown, it gets an `aria-disabled=true` attr
 
 test('If it receives `ariaLabel="foo123"` it gets an `aria-label="foo123"` attribute', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot ariaLabel="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger ariaLabel="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-label'), 'foo123', 'the aria-label is set');
 });
 
 test('If it receives `ariaLabelledBy="foo123"` it gets an `aria-labelledby="foo123"` attribute', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot ariaLabelledBy="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger ariaLabelledBy="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-labelledby'), 'foo123', 'the aria-labelledby is set');
 });
 
 test('If it receives `ariaDescribedBy="foo123"` it gets an `aria-describedby="foo123"` attribute', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot ariaDescribedBy="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger ariaDescribedBy="foo123" dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   assert.equal(this.$('.ember-basic-dropdown-trigger').attr('aria-describedby'), 'foo123', 'the aria-describedby is set');
 });
 
 test('If it receives `ariaRequired="true"` it gets an `aria-required="true"` attribute', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.required = true;
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot ariaRequired=required dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger ariaRequired=required dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('aria-required'), 'true', 'the aria-required is true');
@@ -131,11 +121,10 @@ test('If it receives `ariaRequired="true"` it gets an `aria-required="true"` att
 
 test('If it receives `ariaInvalid="true"` it gets an `aria-invalid="true"` attribute', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.invalid = true;
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot ariaInvalid=invalid dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger ariaInvalid=invalid dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('aria-invalid'), 'true', 'the aria-invalid is true');
@@ -145,10 +134,9 @@ test('If it receives `ariaInvalid="true"` it gets an `aria-invalid="true"` attri
 
 test('If the received dropdown is open, it has an `aria-expanded="true"` attribute', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123, isOpen: false };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('aria-expanded'), undefined, 'the aria-expanded is false');
@@ -158,10 +146,9 @@ test('If the received dropdown is open, it has an `aria-expanded="true"` attribu
 
 test('If the received dropdown is open, it has an `aria-pressed="true"` attribute', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123, isOpen: false };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('aria-pressed'), undefined, 'the aria-pressed is false');
@@ -171,10 +158,9 @@ test('If the received dropdown is open, it has an `aria-pressed="true"` attribut
 
 test('If it has an `aria-controls="foo123"` attribute pointing to the id of the content', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('aria-controls'), 'ember-basic-dropdown-content-123');
@@ -182,10 +168,9 @@ test('If it has an `aria-controls="foo123"` attribute pointing to the id of the 
 
 test('If it receives `role="foo123"` it gets that attribute', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown role="foo123"}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown role="foo123"}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('role'), 'foo123');
@@ -193,10 +178,9 @@ test('If it receives `role="foo123"` it gets that attribute', function(assert) {
 
 test('If it does not receive an specific `role`, the default is `button`', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.equal($trigger.attr('role'), 'button');
@@ -204,10 +188,9 @@ test('If it does not receive an specific `role`, the default is `button`', funct
 
 test('It has `aria-haspopup=true`', function(assert) {
   assert.expect(1);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
   assert.ok(['true', ''].indexOf($trigger.attr('aria-haspopup') > -1), 'Has `aria-haspopup=true`');
@@ -216,14 +199,13 @@ test('It has `aria-haspopup=true`', function(assert) {
 // Custom actions
 test('If it receives an `onMouseEnter` action, it will be invoked when a mouseenter event is received', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123 };
   this.onMouseEnter = (dropdown, e) => {
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onMouseEnter=onMouseEnter}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown onMouseEnter=onMouseEnter}}Click me{{/basic-dropdown/trigger}}
   `);
   run(() => {
     let event = new window.Event('mouseenter', { bubbles: true, cancelable: true, view: window });
@@ -233,14 +215,13 @@ test('If it receives an `onMouseEnter` action, it will be invoked when a mouseen
 
 test('If it receives an `onMouseLeave` action, it will be invoked when a mouseleave event is received', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.onMouseLeave = (dropdown, e) => {
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onMouseLeave=onMouseLeave}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown onMouseLeave=onMouseLeave}}Click me{{/basic-dropdown/trigger}}
   `);
   run(() => {
     let event = new window.Event('mouseleave', { bubbles: true, cancelable: true, view: window });
@@ -250,28 +231,26 @@ test('If it receives an `onMouseLeave` action, it will be invoked when a mousele
 
 test('If it receives an `onFocus` action, it will be invoked when it get focused', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.onFocus = (dropdown, e) => {
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onFocus=onFocus}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown onFocus=onFocus}}Click me{{/basic-dropdown/trigger}}
   `);
   run(() => this.$('.ember-basic-dropdown-trigger')[0].focus());
 });
 
 test('If it receives an `onBlur` action, it will be invoked when it get blurred', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.onBlur = (dropdown, e) => {
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
   };
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onBlur=onBlur}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown onBlur=onBlur}}Click me{{/basic-dropdown/trigger}}
   `);
   run(() => this.$('.ember-basic-dropdown-trigger')[0].focus());
   run(() => this.$('.ember-basic-dropdown-trigger')[0].blur());
@@ -279,7 +258,6 @@ test('If it receives an `onBlur` action, it will be invoked when it get blurred'
 
 test('If it receives an `onKeydown` action, it will be invoked when a key is pressed while the component is focused', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.onKeydown = (dropdown, e) => {
     assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
     assert.ok(e instanceof window.Event, 'It receives the event as second argument');
@@ -287,7 +265,7 @@ test('If it receives an `onKeydown` action, it will be invoked when a key is pre
   };
   this.dropdown = { uniqueId: 123 };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onKeydown=onKeydown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown onKeydown=onKeydown}}Click me{{/basic-dropdown/trigger}}
   `);
   fireKeydown('.ember-basic-dropdown-trigger', 70);
 });
@@ -295,7 +273,6 @@ test('If it receives an `onKeydown` action, it will be invoked when a key is pre
 // Default behaviour
 test('Clicking invokes the `toggle` action on the dropdown', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: 123,
     actions: {
@@ -306,14 +283,13 @@ test('Clicking invokes the `toggle` action on the dropdown', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   clickTrigger();
 });
 
 test('Pressing ENTER fires the `toggle` action on the dropdown', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: 123,
     actions: {
@@ -324,7 +300,7 @@ test('Pressing ENTER fires the `toggle` action on the dropdown', function(assert
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   fireKeydown('.ember-basic-dropdown-trigger', 13);
@@ -332,7 +308,6 @@ test('Pressing ENTER fires the `toggle` action on the dropdown', function(assert
 
 test('Pressing SPACE fires the `toggle` action on the dropdown and preventsDefault to avoid scrolling', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: 123,
     actions: {
@@ -344,7 +319,7 @@ test('Pressing SPACE fires the `toggle` action on the dropdown and preventsDefau
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   fireKeydown('.ember-basic-dropdown-trigger', 32);
@@ -352,7 +327,6 @@ test('Pressing SPACE fires the `toggle` action on the dropdown and preventsDefau
 
 test('Pressing ESC fires the `close` action on the dropdown', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: 123,
     actions: {
@@ -363,7 +337,7 @@ test('Pressing ESC fires the `close` action on the dropdown', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   fireKeydown('.ember-basic-dropdown-trigger', 27);
@@ -371,7 +345,6 @@ test('Pressing ESC fires the `close` action on the dropdown', function(assert) {
 
 test('Pressing ENTER/SPACE/ESC does nothing of the onKeydown action returns false', function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.onKeydown = () => false;
   this.dropdown = {
     uniqueId: 123,
@@ -385,7 +358,7 @@ test('Pressing ENTER/SPACE/ESC does nothing of the onKeydown action returns fals
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onKeydown=onKeydown}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown onKeydown=onKeydown}}Click me{{/basic-dropdown/trigger}}
   `);
 
   fireKeydown('.ember-basic-dropdown-trigger', 13);
@@ -395,7 +368,6 @@ test('Pressing ENTER/SPACE/ESC does nothing of the onKeydown action returns fals
 
 test('Tapping invokes the toggle action on the dropdown', function(assert) {
   assert.expect(2);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     actions: {
       uniqueId: 123,
@@ -406,14 +378,13 @@ test('Tapping invokes the toggle action on the dropdown', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
   `);
   tapTrigger();
 });
 
 test('Firing a mousemove between a touchstart and a touchend (touch scroll) doesn\'t fire the toggle action', function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: 123,
     actions: {
@@ -423,7 +394,7 @@ test('Firing a mousemove between a touchstart and a touchend (touch scroll) does
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
   `);
   let trigger = this.$('.ember-basic-dropdown-trigger').get(0);
   run(() => trigger.dispatchEvent(new window.Event('touchstart', { bubbles: true, cancelable: true, view: window })));
@@ -433,7 +404,6 @@ test('Firing a mousemove between a touchstart and a touchend (touch scroll) does
 
 test('If its dropdown is disabled it won\'t respond to mouse, touch or keyboard event', function(assert) {
   assert.expect(0);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = {
     uniqueId: 123,
     disabled: true,
@@ -450,7 +420,7 @@ test('If its dropdown is disabled it won\'t respond to mouse, touch or keyboard 
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
+    {{#basic-dropdown/trigger dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
   `);
   clickTrigger();
   tapTrigger();
@@ -462,7 +432,6 @@ test('If its dropdown is disabled it won\'t respond to mouse, touch or keyboard 
 // Focus
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired on the trigger', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123, isOpen: true, actions: { reposition() { } } };
   this.onFocusIn = (api, e) => {
     assert.ok(true, 'The action is invoked');
@@ -470,7 +439,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onFocusIn=onFocusIn}}
+    {{#basic-dropdown/trigger dropdown=dropdown onFocusIn=onFocusIn}}
       <input type="text" id="test-input-focusin" />
     {{/basic-dropdown/trigger}}
   `);
@@ -480,7 +449,6 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
 
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired on the trigger', function(assert) {
   assert.expect(3);
-  this.appRoot = document.querySelector('#ember-testing');
   this.dropdown = { uniqueId: 123, isOpen: true, actions: { reposition() { } } };
   this.onFocusOut = (api, e) => {
     assert.ok(true, 'The action is invoked');
@@ -488,7 +456,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/trigger appRoot=appRoot dropdown=dropdown onFocusOut=onFocusOut}}
+    {{#basic-dropdown/trigger dropdown=dropdown onFocusOut=onFocusOut}}
       <input type="text" id="test-input-focusout" />
     {{/basic-dropdown/trigger}}
   `);


### PR DESCRIPTION
Initially I was over cautious because I wanted to prevent any memory leak in testing, but that actually means that if the app's root is not the body, the component doesn't close when clicking in that non-ember frame.

