### PR TITLE
Make uniqueId to use Ember.guidFor

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import layout from '../templates/components/basic-dropdown';
 import { join } from 'ember-runloop';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
+import { guidFor } from 'ember-metal/utils';
 
 const assign = Object.assign || function EmberAssign(original, ...args) {
   for (let i = 0; i < args.length; i++) {
@@ -21,8 +22,6 @@ const assign = Object.assign || function EmberAssign(original, ...args) {
 
   return original;
 };
-
-let instancesCounter = 0;
 
 export default Component.extend({
   layout,
@@ -47,10 +46,8 @@ export default Component.extend({
     this._super(...arguments);
     this.set('publicAPI', {});
 
-    instancesCounter++;
-
     let publicAPI = this.updateState({
-      uniqueId: instancesCounter++,
+      uniqueId: guidFor(this),
       isOpen: this.get('initiallyOpened') || false,
       disabled: this.get('disabled') || false,
       actions: {

--- a/tests/integration/components/basic-dropdown/content-test.js
+++ b/tests/integration/components/basic-dropdown/content-test.js
@@ -10,7 +10,7 @@ moduleForComponent('ember-basic-dropdown', 'Integration | Component | basic-drop
 // Basic rendering
 test('If the dropdown is open renders the given block in a div with class `ember-basic-dropdown-content`', function(assert) {
   assert.expect(2);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -21,7 +21,7 @@ test('If the dropdown is open renders the given block in a div with class `ember
 
 test('If the dropdown is closed, nothing is rendered', function(assert) {
   assert.expect(1);
-  this.dropdown = { uniqueId: '123', isOpen: false };
+  this.dropdown = { uniqueId: 'e123', isOpen: false };
   this.render(hbs`
     {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -31,7 +31,7 @@ test('If the dropdown is closed, nothing is rendered', function(assert) {
 
 test('If it receives `renderInPlace=true`, it is rendered right here instead of elsewhere', function(assert) {
   assert.expect(2);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content dropdown=dropdown renderInPlace=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -42,7 +42,7 @@ test('If it receives `renderInPlace=true`, it is rendered right here instead of 
 
 test('If it receives `to="foo123"`, it is rendered in the element with that ID', function(assert) {
   assert.expect(2);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     <div id="foo123"></div>
     {{#basic-dropdown/content dropdown=dropdown to="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
@@ -54,17 +54,17 @@ test('If it receives `to="foo123"`, it is rendered in the element with that ID',
 
 test('It derives the ID of the content from the `uniqueId` property of of the dropdown', function(assert) {
   assert.expect(1);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let $content = $('.ember-basic-dropdown-content');
-  assert.equal($content.attr('id'), 'ember-basic-dropdown-content-123', 'contains the expected ID');
+  assert.equal($content.attr('id'), 'ember-basic-dropdown-content-e123', 'contains the expected ID');
 });
 
 test('If it receives `class="foo123"`, the rendered content will have that class along with the default one', function(assert) {
   assert.expect(1);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     {{#basic-dropdown/content dropdown=dropdown class="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
@@ -86,7 +86,7 @@ test('If it receives `dir="rtl"`, the rendered content will have the attribute s
 test('Clicking anywhere in the app outside the component will invoke the close action on the dropdown', function(assert) {
   assert.expect(1);
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       close() {
@@ -109,7 +109,7 @@ test('Clicking anywhere in the app outside the component will invoke the close a
 test('Clicking anywhere inside the dropdown content doesn\'t invoke the close action', function(assert) {
   assert.expect(0);
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       close() {
@@ -168,7 +168,7 @@ test('Clicking in inside the a dropdown content nested inside another dropdown c
 test('Tapping anywhere in the app outside the component will invoke the close action on the dropdown', function(assert) {
   assert.expect(1);
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       close() {
@@ -193,7 +193,7 @@ test('Tapping anywhere in the app outside the component will invoke the close ac
 test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside the component will invoke the close action on the dropdown', function(assert) {
   assert.expect(0);
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       close() {
@@ -220,7 +220,7 @@ test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside 
 // Focus
 test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired inside the content', function(assert) {
   assert.expect(3);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.onFocusIn = (api, e) => {
     assert.ok(true, 'The action is invoked');
     assert.equal(api, this.dropdown, 'The first argument is the API');
@@ -237,7 +237,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
 
 test('If it receives an `onFocusOut` action, it is invoked if a focusout event is fired inside the content', function(assert) {
   assert.expect(3);
-  this.dropdown = { uniqueId: '123', isOpen: true, actions: { reposition() { } } };
+  this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.onFocusOut = (api, e) => {
     assert.ok(true, 'The action is invoked');
     assert.equal(api, this.dropdown, 'The first argument is the API');
@@ -257,7 +257,7 @@ test('If it receives an `onFocusOut` action, it is invoked if a focusout event i
 test('The component is repositioned immediatly when opened', function(assert) {
   assert.expect(1);
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       reposition() {
@@ -273,7 +273,7 @@ test('The component is repositioned immediatly when opened', function(assert) {
 test('The component is not repositioned if it is closed', function(assert) {
   assert.expect(0);
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: false,
     actions: {
       reposition() {
@@ -290,7 +290,7 @@ test('The component is repositioned if the window scrolls', function(assert) {
   assert.expect(1);
   let repositions = 0;
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       reposition() {
@@ -309,7 +309,7 @@ test('The component is repositioned if the window is resized', function(assert) 
   assert.expect(1);
   let repositions = 0;
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       reposition() {
@@ -328,7 +328,7 @@ test('The component is repositioned if the orientation changes', function(assert
   assert.expect(1);
   let repositions = 0;
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       reposition() {
@@ -348,7 +348,7 @@ test('The component is repositioned if the content of the dropdown changs', func
   let done = assert.async();
   let repositions = 0;
   this.dropdown = {
-    uniqueId: '123',
+    uniqueId: 'e123',
     isOpen: true,
     actions: {
       reposition() {


### PR DESCRIPTION
Reasons:

- It's a string, not a number. This is handy in case users what to construct DOM ids that start with
  {{select.uniqueId), because DOM ids cannot start with numbers.
- It's already there, and might be handy to lookup the component in the container by that ID.