### PR TITLE
updates ember-get-config dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ module.exports = {
     var app = appOrAddon.app || appOrAddon;
     if (!app.__emberBasicDropdownIncludedInvoked) {
       app.__emberBasicDropdownIncludedInvoked = true;
+      // for ember-get-config compat
+      // https://github.com/null-null-null/ember-get-config#usage
+      this.eachAddonInvoke('included', [app]);
+      
       this._super.included.apply(this, arguments);
       // Don't include the precompiled css file if the user uses ember-cli-sass
       if (!app.registry.availablePlugins['ember-cli-sass']) {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.10",
     "ember-cli-htmlbars": "^1.1.0",
-    "ember-get-config": "0.0.2",
+    "ember-get-config": "0.1.7",
     "ember-wormhole": "0.4.1"
   },
   "ember-addon": {


### PR DESCRIPTION
This all started as in investigation into [ember-power-select](https://github.com/cibernox/ember-power-select) error that was thrown from [ember-get-config](https://github.com/null-null-null/ember-get-config).

The nature of the original problem is fixed by recent updates to the `ember-get-config` lib. It used to use the `window` for lookups, but has made updates recently for `fastboot` and other contexts where available objects were not defined on the `window`.

This PR bumps the version number of `ember-get-config` to its latest and adds a required setup line to the `index.js` file.