### PR TITLE
Update ember-get-config to a version that works in fastboot

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.10",
     "ember-cli-htmlbars": "^1.1.0",
-    "ember-get-config": "0.0.2",
+    "ember-get-config": "0.1.8",
     "ember-wormhole": "0.4.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Closes #157

Since this issue (https://github.com/null-null-null/ember-get-config/issues/10), no calls special magic is required