### PR TITLE
The approach based in transitions is fundamentally flawed. Animations still work

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -15,13 +15,7 @@ const rAF = self.window.requestAnimationFrame || function(cb) {
 function waitForAnimations(element, callback) {
   rAF(function() {
     let computedStyle = self.window.getComputedStyle(element);
-    if (computedStyle.transitionDuration && computedStyle.transitionDuration !== '0s') {
-      let eventCallback = function() {
-        element.removeEventListener('transitionend', eventCallback);
-        callback();
-      };
-      element.addEventListener('transitionend', eventCallback);
-    } else if (computedStyle.animationName !== 'none' && computedStyle.animationPlayState === 'running') {
+    if (computedStyle.animationName !== 'none' && computedStyle.animationPlayState === 'running') {
       let eventCallback = function() {
         element.removeEventListener('animationend', eventCallback);
         callback();


### PR DESCRIPTION
The simple presence of a `transition` property is not enough to guarantee that
a transition is happening, because:

- It only fires if some change in the values affected by the transition, and there is no
  easy way of knowing if a transition is running (unlike animations, which expose that information)
- There is some circunstance in which the animationEnd event doesn't fire depending on the browser,
  by example if the element gets `display: none`.

Because of that, the only approach to animate the component with pure CSS is using CSS3 animations