### PR TITLE
The `calculatePosition` method is now inside /utils so users can import it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+- [ENHANCEMENT] The default `calculatePosition` method is now inside `addon/utils/calculate-position`, so users can import it
+  to perhaps reuse some of the logic in their own positioning functions.
+
+# 0.16.3
+- [BUGFIX] Add forgotten `uniqueId` property to the publicAPI yielded to the block. The `publicAPI` object passes to actions had it
+  but the one in the block didn't.
+
 # 0.16.2
 - [ENHANCEMENT] Allows to customize how the dropdown is positioned by passing a `calculatePosition` function.
 

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -5,6 +5,7 @@ import $ from 'jquery';
 import layout from '../templates/components/basic-dropdown';
 import { join } from 'ember-runloop';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
+import { calculatePosition } from '../utils/calculate-position';
 const { guidFor } = Ember;
 
 const assign = Object.assign || function EmberAssign(original, ...args) {
@@ -33,6 +34,7 @@ export default Component.extend({
   matchTriggerWidth: fallbackIfUndefined(false),
   triggerComponent: fallbackIfUndefined('basic-dropdown/trigger'),
   contentComponent: fallbackIfUndefined('basic-dropdown/content'),
+  calculatePosition: fallbackIfUndefined(calculatePosition),
   classNames: ['ember-basic-dropdown'],
   top: null,
   left: null,
@@ -208,85 +210,5 @@ export default Component.extend({
       registerAPI(newState);
     }
     return newState;
-  },
-
-  /**
-    Function used to calculate the position of the content of the dropdown.
-    @public
-    @method calculatePosition
-    @param {DomElement} trigger The trigger of the dropdown
-    @param {DomElement} dropdown The content of the dropdown
-    @param {Object} options The directives that define how the position is calculated
-      - {String} horizantalPosition How the users want the dropdown to be positioned horizontally. Values: right | center | left
-      - {String} verticalPosition How the users want the dropdown to be positioned vertically. Values: above | below
-      - {Boolean} matchTriggerWidth If the user wants the width of the dropdown to match the width of the trigger
-      - {String} previousHorizantalPosition How the dropdown was positioned for the last time. Same values than horizontalPosition, but can be null the first time.
-      - {String} previousVerticalPosition How the dropdown was positioned for the last time. Same values than verticalPosition, but can be null the first time.
-    @return {Object} How the component is going to be positioned.
-      - {String} horizantalPosition The new horizontal position.
-      - {String} verticalPosition The new vertical position.
-      - {Object} CSS properties to be set on the dropdown. It supports `top`, `left`, `right` and `width`.
-  */
-  calculatePosition(trigger, dropdown, { previousHorizontalPosition, horizontalPosition, previousVerticalPosition, verticalPosition, matchTriggerWidth }) {
-    let $window = $(self.window);
-    let scroll = { left: $window.scrollLeft(), top: $window.scrollTop() };
-    let { left: triggerLeft, top: triggerTop, width: triggerWidth, height: triggerHeight } = trigger.getBoundingClientRect();
-    let { height: dropdownHeight, width: dropdownWidth } = dropdown.getBoundingClientRect();
-    let dropdownLeft = triggerLeft;
-    let dropdownTop;
-    dropdownWidth = matchTriggerWidth ? triggerWidth : dropdownWidth;
-
-    let viewportRight = scroll.left + self.window.innerWidth;
-
-    if (horizontalPosition === 'auto') {
-      let roomForRight = viewportRight - triggerLeft;
-
-      if (roomForRight < dropdownWidth) {
-        horizontalPosition = 'right';
-      } else if (triggerLeft < dropdownWidth) {
-        horizontalPosition = 'left';
-      } else {
-        horizontalPosition = previousHorizontalPosition || 'left';
-      }
-
-    } else if (horizontalPosition === 'right') {
-      dropdownLeft = triggerLeft + triggerWidth - dropdownWidth;
-    } else if (horizontalPosition === 'center') {
-      dropdownLeft = triggerLeft + (triggerWidth - dropdownWidth) / 2;
-    }
-
-    let triggerTopWithScroll = triggerTop + scroll.top;
-    if (verticalPosition === 'above') {
-      dropdownTop = triggerTopWithScroll - dropdownHeight;
-    } else if (verticalPosition === 'below') {
-      dropdownTop = triggerTopWithScroll + triggerHeight;
-    } else {
-      let viewportBottom = scroll.top + self.window.innerHeight;
-      let enoughRoomBelow = triggerTopWithScroll + triggerHeight + dropdownHeight < viewportBottom;
-      let enoughRoomAbove = triggerTop > dropdownHeight;
-
-      if (previousVerticalPosition === 'below' && !enoughRoomBelow && enoughRoomAbove) {
-        verticalPosition = 'above';
-      } else if (previousVerticalPosition === 'above' && !enoughRoomAbove && enoughRoomBelow) {
-        verticalPosition = 'below';
-      } else if (!previousVerticalPosition) {
-        verticalPosition = enoughRoomBelow ? 'below' : 'above';
-      } else {
-        verticalPosition = previousVerticalPosition;
-      }
-      dropdownTop = triggerTopWithScroll + (verticalPosition === 'below' ? triggerHeight : -dropdownHeight);
-    }
-
-    let style = { top: `${dropdownTop}px` };
-    if (horizontalPosition === 'right') {
-      style.right = `${viewportRight - (triggerWidth + triggerLeft)}px`;
-    } else {
-      style.left = `${dropdownLeft}px`;
-    }
-    if (matchTriggerWidth) {
-      style.width = `${dropdownWidth}px`;
-    }
-
-    return { horizontalPosition, verticalPosition, style };
   }
 });

--- a/addon/utils/calculate-position.js
+++ b/addon/utils/calculate-position.js
@@ -1,0 +1,80 @@
+import $ from 'jquery';
+/**
+  Function used to calculate the position of the content of the dropdown.
+  @public
+  @method calculatePosition
+  @param {DomElement} trigger The trigger of the dropdown
+  @param {DomElement} dropdown The content of the dropdown
+  @param {Object} options The directives that define how the position is calculated
+    - {String} horizantalPosition How the users want the dropdown to be positioned horizontally. Values: right | center | left
+    - {String} verticalPosition How the users want the dropdown to be positioned vertically. Values: above | below
+    - {Boolean} matchTriggerWidth If the user wants the width of the dropdown to match the width of the trigger
+    - {String} previousHorizantalPosition How the dropdown was positioned for the last time. Same values than horizontalPosition, but can be null the first time.
+    - {String} previousVerticalPosition How the dropdown was positioned for the last time. Same values than verticalPosition, but can be null the first time.
+  @return {Object} How the component is going to be positioned.
+    - {String} horizantalPosition The new horizontal position.
+    - {String} verticalPosition The new vertical position.
+    - {Object} CSS properties to be set on the dropdown. It supports `top`, `left`, `right` and `width`.
+*/
+export function calculatePosition(trigger, dropdown, { previousHorizontalPosition, horizontalPosition, previousVerticalPosition, verticalPosition, matchTriggerWidth }) {
+  let $window = $(self.window);
+  let scroll = { left: $window.scrollLeft(), top: $window.scrollTop() };
+  let { left: triggerLeft, top: triggerTop, width: triggerWidth, height: triggerHeight } = trigger.getBoundingClientRect();
+  let { height: dropdownHeight, width: dropdownWidth } = dropdown.getBoundingClientRect();
+  let dropdownLeft = triggerLeft;
+  let dropdownTop;
+  dropdownWidth = matchTriggerWidth ? triggerWidth : dropdownWidth;
+
+  let viewportRight = scroll.left + self.window.innerWidth;
+
+  if (horizontalPosition === 'auto') {
+    let roomForRight = viewportRight - triggerLeft;
+
+    if (roomForRight < dropdownWidth) {
+      horizontalPosition = 'right';
+    } else if (triggerLeft < dropdownWidth) {
+      horizontalPosition = 'left';
+    } else {
+      horizontalPosition = previousHorizontalPosition || 'left';
+    }
+
+  } else if (horizontalPosition === 'right') {
+    dropdownLeft = triggerLeft + triggerWidth - dropdownWidth;
+  } else if (horizontalPosition === 'center') {
+    dropdownLeft = triggerLeft + (triggerWidth - dropdownWidth) / 2;
+  }
+
+  let triggerTopWithScroll = triggerTop + scroll.top;
+  if (verticalPosition === 'above') {
+    dropdownTop = triggerTopWithScroll - dropdownHeight;
+  } else if (verticalPosition === 'below') {
+    dropdownTop = triggerTopWithScroll + triggerHeight;
+  } else {
+    let viewportBottom = scroll.top + self.window.innerHeight;
+    let enoughRoomBelow = triggerTopWithScroll + triggerHeight + dropdownHeight < viewportBottom;
+    let enoughRoomAbove = triggerTop > dropdownHeight;
+
+    if (previousVerticalPosition === 'below' && !enoughRoomBelow && enoughRoomAbove) {
+      verticalPosition = 'above';
+    } else if (previousVerticalPosition === 'above' && !enoughRoomAbove && enoughRoomBelow) {
+      verticalPosition = 'below';
+    } else if (!previousVerticalPosition) {
+      verticalPosition = enoughRoomBelow ? 'below' : 'above';
+    } else {
+      verticalPosition = previousVerticalPosition;
+    }
+    dropdownTop = triggerTopWithScroll + (verticalPosition === 'below' ? triggerHeight : -dropdownHeight);
+  }
+
+  let style = { top: `${dropdownTop}px` };
+  if (horizontalPosition === 'right') {
+    style.right = `${viewportRight - (triggerWidth + triggerLeft)}px`;
+  } else {
+    style.left = `${dropdownLeft}px`;
+  }
+  if (matchTriggerWidth) {
+    style.width = `${dropdownWidth}px`;
+  }
+
+  return { horizontalPosition, verticalPosition, style };
+}


### PR DESCRIPTION
This makes easier to the end user to build their own repositioning strategy that
reuses some of the default logic. By example, if a user likes the default strategy
but wants some extra padding, it is now possible to pass a `calculatePosition` that
in turns call the default one, and the programmes just has to increase the `styles.top`
property in the desired amount.