### PR TITLE
Make the `calculatePosition` return numbers without units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- [BREAKING] The object returned by `calculatePosition` now contains the offsets
+  of the dropdown as numbers instead of strings with "px" as unit. This makes easier for people
+  to modify those values in their own functions.
+
 # 0.16.4
 - [ENHANCEMENT] The default `calculatePosition` method is now inside `addon/utils/calculate-position`, so users can import it
   to perhaps reuse some of the logic in their own positioning functions.

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -177,10 +177,16 @@ export default Component.extend({
       vPosition: positions.verticalPosition
     };
     if (positions.style) {
-      changes.top = positions.style.top;
-      changes.left = positions.style.left;
-      changes.right = positions.style.right;
-      changes.width = positions.style.width;
+      changes.top = `${positions.style.top}px`;
+      if (positions.style.left !== undefined) {
+        changes.left = `${positions.style.left}px`;
+      }
+      if (positions.style.right !== undefined) {
+        changes.right = `${positions.style.right}px`;
+      }
+      if (positions.style.width !== undefined) {
+        changes.width = `${positions.style.width}px`;
+      }
       if (this.get('top') === null) {
         // Bypass Ember on the first reposition only to avoid flickering.
         $(dropdown).css(positions.style);

--- a/addon/utils/calculate-position.js
+++ b/addon/utils/calculate-position.js
@@ -66,14 +66,14 @@ export function calculatePosition(trigger, dropdown, { previousHorizontalPositio
     dropdownTop = triggerTopWithScroll + (verticalPosition === 'below' ? triggerHeight : -dropdownHeight);
   }
 
-  let style = { top: `${dropdownTop}px` };
+  let style = { top: dropdownTop };
   if (horizontalPosition === 'right') {
-    style.right = `${viewportRight - (triggerWidth + triggerLeft)}px`;
+    style.right = viewportRight - (triggerWidth + triggerLeft);
   } else {
-    style.left = `${dropdownLeft}px`;
+    style.left = dropdownLeft;
   }
   if (matchTriggerWidth) {
-    style.width = `${dropdownWidth}px`;
+    style.width = dropdownWidth;
   }
 
   return { horizontalPosition, verticalPosition, style };

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -476,7 +476,7 @@ test('The user can pass a custom `calculatePosition` function to customize how t
   let $dropdownContent = $('.ember-basic-dropdown-content');
   assert.ok($dropdownContent.hasClass('ember-basic-dropdown-content--above'), 'The dropdown is above');
   assert.ok($dropdownContent.hasClass('ember-basic-dropdown-content--right'), 'The dropdown is in the right');
-  assert.equal($dropdownContent.attr('style'), 'top: 111;right: 222;', 'The style attribute is the expected one');
+  assert.equal($dropdownContent.attr('style'), 'top: 111px;right: 222px;', 'The style attribute is the expected one');
 });
 
 // Customization of inner components


### PR DESCRIPTION
Before this change, the object returned by `calculatePosition` looked
like:
```json
{"horizontalPosition":"right","verticalPosition":"below","style":{"top":"44.5px","right":"327.15625px"}}
```

After this change it looks like:

```
{"horizontalPosition":"right","verticalPosition":"below","style":{"top":44.5,"right":327.15625}}
```

This changes makes easier for people to rely on the default behaviour and manipulate
the values, since they are numbers instead of strings