### PR TITLE
Don't call `e.preventDefault` on touchend

### DIFF
--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -161,7 +161,6 @@ export default Component.extend({
       });
       this.element.addEventListener('touchend', (e) => {
         this.send('handleTouchEnd', e);
-        e.preventDefault(); // Prevent synthetic click
       });
     }
     this.element.addEventListener('mousedown', (e) => this.send('handleMousedown', e));


### PR DESCRIPTION
Chrome doesn't like it and it also prevents the inputs inside to get focus
and open the virtual keyboard in mobile