### PR TITLE
call calculatePosition with context set to the component

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -148,7 +148,7 @@ export default Component.extend({
 
     let calculatePosition = this.get(this.get('renderInPlace') ? 'calculateInPlacePosition' : 'calculatePosition');
     let options = this.getProperties('horizontalPosition', 'verticalPosition', 'matchTriggerWidth', 'previousHorizontalPosition', 'previousVerticalPosition');
-    let positionData = calculatePosition(triggerElement, dropdownElement, options);
+    let positionData = calculatePosition.call(this, triggerElement, dropdownElement, options);
     return this.applyReposition(triggerElement, dropdownElement, positionData);
   },
 

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -148,7 +148,8 @@ export default Component.extend({
 
     let calculatePosition = this.get(this.get('renderInPlace') ? 'calculateInPlacePosition' : 'calculatePosition');
     let options = this.getProperties('horizontalPosition', 'verticalPosition', 'matchTriggerWidth', 'previousHorizontalPosition', 'previousVerticalPosition');
-    let positionData = calculatePosition.call(this, triggerElement, dropdownElement, options);
+    options.dropdown = this;
+    let positionData = calculatePosition(triggerElement, dropdownElement, options);
     return this.applyReposition(triggerElement, dropdownElement, positionData);
   },
 

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -477,8 +477,9 @@ test('The `reposition` public action returns an object with the changes', functi
 });
 
 test('The user can pass a custom `calculatePosition` function to customize how the component is placed on the screen', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
   this.calculatePosition = function() {
+    assert.ok(this, 'context shouldn\'t be undefined');
     return {
       horizontalPosition: 'right',
       verticalPosition: 'above',
@@ -504,8 +505,9 @@ test('The user can pass a custom `calculatePosition` function to customize how t
 });
 
 test('The user can pass a custom `calculateInPlacePosition` function to customize how the component is placed on the screen when rendered "in place"', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
   this.calculateInPlacePosition = function() {
+    assert.ok(this, 'context shouldn\'t be undefined');
     return {
       horizontalPosition: 'right',
       verticalPosition: 'above',

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -478,8 +478,8 @@ test('The `reposition` public action returns an object with the changes', functi
 
 test('The user can pass a custom `calculatePosition` function to customize how the component is placed on the screen', function(assert) {
   assert.expect(4);
-  this.calculatePosition = function() {
-    assert.ok(this, 'context shouldn\'t be undefined');
+  this.calculatePosition = function(triggerElement, dropdownElement, { dropdown }) {
+    assert.ok(dropdown, 'dropdown should be passed to the component');
     return {
       horizontalPosition: 'right',
       verticalPosition: 'above',
@@ -506,8 +506,8 @@ test('The user can pass a custom `calculatePosition` function to customize how t
 
 test('The user can pass a custom `calculateInPlacePosition` function to customize how the component is placed on the screen when rendered "in place"', function(assert) {
   assert.expect(4);
-  this.calculateInPlacePosition = function() {
-    assert.ok(this, 'context shouldn\'t be undefined');
+  this.calculateInPlacePosition = function(triggerElement, dropdownElement, { dropdown }) {
+    assert.ok(dropdown, 'dropdown should be passed to the component');
     return {
       horizontalPosition: 'right',
       verticalPosition: 'above',


### PR DESCRIPTION
We'd like to use eps `calculatePosition` hook in ember-paper. What is stopping us from that is that we need access to the component to get some options the user can provide.
We've done that through the function's context.

You probably don't want to leak internal stuff into public APIs, but this could be a solution for our problem.