### PR TITLE
Permit overrides of default handleMousedown, handleKeydown, handleTouchend actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ npm-debug.log*
 testem.log
 .vscode
 .env.deploy.*
+/.idea

--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -115,6 +115,12 @@ export default Component.extend({
         return;
       }
       this.stopTextSelectionUntilMouseup();
+      // execute user-supplied onMousedown function before default toggle action;
+      // short-circuit default behavior if user-supplied function returns `false`
+      let onMousedown = this.get('onMousedown');
+      if (onMousedown && onMousedown(dropdown, e) === false) {
+        return;
+      }
       dropdown.actions.toggle(e);
     },
 
@@ -125,6 +131,12 @@ export default Component.extend({
         return;
       }
       if (!this.hasMoved) {
+        // execute user-supplied onTouchend function before default toggle action;
+        // short-circuit default behavior if user-supplied function returns `false`
+        let onTouchend = this.get('onTouchend');
+        if (onTouchend && onTouchend(dropdown, e) === false) {
+          return;
+        }
         dropdown.actions.toggle(e);
       }
       this.hasMoved = false;

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -486,3 +486,158 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
   run(() => input.focus());
 });
 
+// Decorating and overriding default event handlers
+test('A user-supplied onMousedown action will execute before the default toggle behavior', function(assert) {
+  assert.expect(4);
+  let userActionRanfirst = false;
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {
+        assert.ok(userActionRanfirst, 'User-supplied `onMousedown` ran before default `toggle`');
+      }
+    }
+  };
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    assert.ok(e instanceof window.Event, 'It receives the event');
+    assert.equal(dropdown, this.dropdown, 'It receives the dropdown configuration object');
+    userActionRanfirst = true;
+  };
+
+  this.set('onMousedown', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onMousedown=onMousedown dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+  `);
+
+  clickTrigger();
+});
+
+test('A user-supplied onMousedown action, returning `false`, will prevent the default behavior', function(assert) {
+  assert.expect(1);
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {
+        assert.ok(false, 'Default `toggle` action should not run');
+      }
+    }
+  };
+
+  let userSuppliedAction = () => {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    return false;
+  };
+
+  this.set('onMousedown', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onMousedown=onMousedown dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+  `);
+
+  clickTrigger();
+});
+
+test('A user-supplied onTouchend action will execute before the default toggle behavior', function(assert) {
+  assert.expect(4);
+  let userActionRanfirst = false;
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {
+        assert.ok(userActionRanfirst, 'User-supplied `onTouchend` ran before default `toggle`');
+      }
+    }
+  };
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(true, 'The `userSuppliedAction` action has been fired');
+    assert.ok(e instanceof window.Event, 'It receives the event');
+    assert.equal(dropdown, this.dropdown, 'It receives the dropdown configuration object');
+    userActionRanfirst = true;
+  };
+
+  this.set('onTouchend', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onTouchend=onTouchend dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
+  `);
+  tapTrigger();
+});
+
+test('A user-supplied onTouchend action, returning `false`, will prevent the default behavior', function(assert) {
+  assert.expect(1);
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {
+        assert.ok(false, 'Default `toggle` action should not run');
+      }
+    }
+  };
+
+  let userSuppliedAction = () => {
+    assert.ok(true, 'The `userSuppliedAction` action has been fired');
+    return false;
+  };
+
+  this.set('onTouchend', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onTouchend=onTouchend dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
+  `);
+  tapTrigger();
+});
+
+test('A user-supplied onKeydown action will execute before the default toggle behavior', function(assert) {
+  assert.expect(4);
+  let userActionRanfirst = false;
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {
+        assert.ok(userActionRanfirst, 'User-supplied `onKeydown` ran before default `toggle`');
+      }
+    }
+  };
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    assert.ok(e instanceof window.Event, 'It receives the event');
+    assert.equal(dropdown, this.dropdown, 'It receives the dropdown configuration object');
+    userActionRanfirst = true;
+  };
+
+  this.set('onKeydown', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onKeydown=onKeydown dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+  `);
+  fireKeydown('.ember-basic-dropdown-trigger', 13); // Enter
+});
+
+test('A user-supplied onKeydown action, returning `false`, will prevent the default behavior', function(assert) {
+  assert.expect(1);
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {
+        assert.ok(false, 'Default `toggle` action should not run');
+      }
+    }
+  };
+
+  let userSuppliedAction = () => {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    return false;
+  };
+
+  this.set('onKeydown', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onKeydown=onKeydown dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+  `);
+  fireKeydown('.ember-basic-dropdown-trigger', 13); // Enter
+});


### PR DESCRIPTION
When using the Ember Basic Dropdown with custom events, it is sometimes desirable (in my case necessary) to override the default event handlers, particularly when working with the `mouseenter`/`mouseleave` optional handlers. 

Also added `dropdown` as a parameter for the default handlers (and their bound overrides, if applicable) for consistency with the optional handlers. 

Added tests for the new functionality, and aimed for consistency with existing test suite and application code. 

Thanks for the great project!