### PR TITLE
Feature/dropdown container event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ npm-debug.log*
 testem.log
 .vscode
 .env.deploy.*
+/.idea

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -66,6 +66,13 @@ export default Component.extend({
     this.dropdownId = this.dropdownId || `ember-basic-dropdown-content-${publicAPI.uniqueId}`;
   },
 
+  didInsertElement() {
+    // We cannot add these handlers to a dropdown container that does not exist
+    if (this.get('tagName') !== '') {
+      this.addOptionalHandlers();
+    }
+  },
+
   didReceiveAttrs() {
     this._super(...arguments);
     let oldDisabled = !!this._oldDisabled;
@@ -93,7 +100,15 @@ export default Component.extend({
       if (onFocus) {
         onFocus(this.get('publicAPI'), e);
       }
-    }
+    },
+
+    // Mouseenter/leave, Focusin/out are useful at the dropdown component level (rather than trigger or content)
+    // as we typically want mouseleave/focusout events fired when the related target is outside
+    // *both* the trigger and content
+    handleMouseEnter: Ember.K,
+    handleMouseLeave: Ember.K,
+    handleFocusIn: Ember.K,
+    handleFocusOut: Ember.K
   },
 
   // Methods
@@ -209,5 +224,29 @@ export default Component.extend({
       registerAPI(newState);
     }
     return newState;
+  },
+
+  // For dropdowns utilizing mouseenter/mouseleave and focusin/focusout, it often makes sense to track the
+  // events for the dropdown as a whole (e.g. when hovering over dropdown.content's element, we may not wish to
+  // call dropdown.trigger's mouseleave, potentially closing the dropdown)
+  addOptionalHandlers() {
+    let dropdown = this.get('publicAPI');
+
+    let onMouseEnter = this.get('onMouseEnter');
+    if (onMouseEnter) {
+      this.element.addEventListener('mouseenter', (e) => onMouseEnter(dropdown, e));
+    }
+    let onMouseLeave = this.get('onMouseLeave');
+    if (onMouseLeave) {
+      this.element.addEventListener('mouseleave', (e) => onMouseLeave(dropdown, e));
+    }
+    let onFocusIn = this.get('onFocusIn');
+    if (onFocusIn) {
+      this.element.addEventListener('focusin', (e) => onFocusIn(dropdown, e));
+    }
+    let onFocusOut = this.get('onFocusOut');
+    if (onFocusOut) {
+      this.element.addEventListener('focusout', (e) => onFocusOut(dropdown, e));
+    }
   }
 });

--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -54,6 +54,7 @@ export default Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
+    this.assignHandlerOverrides();
     this.addMandatoryHandlers();
     this.addOptionalHandlers();
   },
@@ -102,7 +103,9 @@ export default Component.extend({
 
   // Actions
   actions: {
-    handleMousedown(e) {
+    handleMousedown(dropdown, e) {
+      dropdown = dropdown || this.get('dropdown');
+
       if (this.skipHandleMousedown) {
         // Some devises have both touchscreen & mouse, and they are not mutually exclusive
         // In those cases the touchdown handler is fired first, and it sets a flag to
@@ -110,7 +113,6 @@ export default Component.extend({
         this.skipHandleMousedown = false;
         return;
       }
-      let dropdown = this.get('dropdown');
       if (dropdown.disabled) {
         return;
       }
@@ -118,9 +120,10 @@ export default Component.extend({
       dropdown.actions.toggle(e);
     },
 
-    handleTouchEnd(e) {
+    handleTouchend(dropdown, e) {
+      dropdown = dropdown || this.get('dropdown');
+
       this.skipHandleMousedown = true;
-      let dropdown = this.get('dropdown');
       if (e && e.defaultPrevented || dropdown.disabled) {
         return;
       }
@@ -139,8 +142,8 @@ export default Component.extend({
       e.preventDefault();
     },
 
-    handleKeydown(e) {
-      let dropdown = this.get('dropdown');
+    handleKeydown(dropdown, e) {
+      dropdown = dropdown || this.get('dropdown');
       if (dropdown.disabled) {
         return;
       }
@@ -171,18 +174,21 @@ export default Component.extend({
   },
 
   addMandatoryHandlers() {
+    let dropdown = this.get('dropdown');
+
     if (this.get('isTouchDevice')) {
       this.element.addEventListener('touchstart', () => {
         self.document.body.addEventListener('touchmove', this._touchMoveHandler);
       });
-      this.element.addEventListener('touchend', (e) => this.send('handleTouchEnd', e));
+      this.element.addEventListener('touchend', (e) => this.send('handleTouchend', dropdown, e));
     }
-    this.element.addEventListener('mousedown', (e) => this.send('handleMousedown', e));
-    this.element.addEventListener('keydown', (e) => this.send('handleKeydown', e));
+    this.element.addEventListener('mousedown', (e) => this.send('handleMousedown', dropdown, e));
+    this.element.addEventListener('keydown', (e) => this.send('handleKeydown', dropdown, e));
   },
 
   addOptionalHandlers() {
     let dropdown = this.get('dropdown');
+
     let onMouseEnter = this.get('onMouseEnter');
     if (onMouseEnter) {
       this.element.addEventListener('mouseenter', (e) => onMouseEnter(dropdown, e));
@@ -207,5 +213,11 @@ export default Component.extend({
     if (onFocusOut) {
       this.element.addEventListener('focusout', (e) => onFocusOut(dropdown, e));
     }
+  },
+
+  assignHandlerOverrides() {
+    this.actions.handleMousedown = this.get('onMousedownOverride') || this.actions.handleMousedown;
+    this.actions.handleKeydown = this.get('onKeydownOverride') || this.actions.handleKeydown;
+    this.actions.handleTouchend = this.get('onTouchendOverride') || this.actions.handleTouchend;
   }
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -33,6 +33,13 @@ export default Ember.Controller.extend({
 
     stopAddingContent() {
       window.clearInterval(this.intervarTimer);
+    },
+
+    openDropdown(dropdown) {
+      Ember.set(dropdown, 'isOpen', true);
+    },
+    closeDropdown(dropdown) {
+      Ember.set(dropdown, 'isOpen', false);
     }
   }
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -94,7 +94,14 @@
 
 <h4>Dropdown in a box with enough padding to have to be rendered on the left sometimes</h4>
 <div style="margin-left: 600px">
-  {{#basic-dropdown as |dropdown|}}
+  {{#basic-dropdown
+    renderInPlace=true
+    onMouseEnter=(action "openDropdown")
+    onMouseLeave=(action "closeDropdown")
+    onFocusIn=(action "openDropdown")
+    onFocusOut=(action "closeDropdown")
+    as |dropdown|
+  }}
     {{#dropdown.trigger tagName="button"}}Click me{{/dropdown.trigger}}
     {{#dropdown.content}}
       <div style="width: 200px; border: 1px solid blue; margin: 10px;">

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -601,6 +601,123 @@ test('The registerAPI is called with every mutation of the publicAPI object', fu
   assert.equal(apis[3].disabled, true, 'and it became disabled');
 });
 
+// Optional dropdown-wide event handlers (mouseenter/mouseleave, focusin/focusout)
+test('If it receives an `onMouseEnter` action, it will be invoked when a mouseenter event is received', function(assert) {
+  assert.expect(1);
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(e instanceof window.Event, 'It receives the event as second argument');
+  };
+  this.set('onMouseEnter', userSuppliedAction);
+
+  this.render(hbs`
+    {{#basic-dropdown
+      onMouseEnter=onMouseEnter
+      renderInPlace=true
+      as |dropdown|
+    }}
+      {{#dropdown.trigger}}Open me{{/dropdown.trigger}}
+      {{#dropdown.content}}<h3>Content of the dropdown</h3>{{/dropdown.content}}
+    {{/basic-dropdown}}
+  `);
+
+  // TODO: @jewilkin - surely there's a cleaner way to do this, but this.element and
+  // this.get('element') return undefined here
+  let [$dropdown] = this.$('.ember-basic-dropdown');
+
+  run(() => {
+    let event = new window.Event('mouseenter', { bubbles: true, cancelable: true, view: window });
+    $dropdown.dispatchEvent(event);
+  });
+});
+
+test('If it receives an `onMouseLeave` action, it will be invoked when a mouseleave event is received', function(assert) {
+  assert.expect(1);
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(e instanceof window.Event, 'It receives the event as second argument');
+  };
+  this.set('onMouseLeave', userSuppliedAction);
+
+  this.render(hbs`
+    {{#basic-dropdown
+      onMouseLeave=onMouseLeave
+      renderInPlace=true
+      as |dropdown|
+    }}
+      {{#dropdown.trigger}}Open me{{/dropdown.trigger}}
+      {{#dropdown.content}}<h3>Content of the dropdown</h3>{{/dropdown.content}}
+    {{/basic-dropdown}}
+  `);
+
+  // TODO: @jewilkin - surely there's a cleaner way to do this, but this.element and
+  // this.get('element') return undefined here
+  let [$dropdown] = this.$('.ember-basic-dropdown');
+
+  run(() => {
+    let event = new window.Event('mouseleave', { bubbles: true, cancelable: true, view: window });
+    $dropdown.dispatchEvent(event);
+  });
+});
+
+test('If it receives an `onFocusIn` action, it will be invoked when a focusin event is received', function(assert) {
+  assert.expect(1);
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(e instanceof window.Event, 'It receives the event as second argument');
+  };
+  this.set('onFocusIn', userSuppliedAction);
+
+  this.render(hbs`
+    {{#basic-dropdown
+      onFocusIn=onFocusIn
+      renderInPlace=true
+      as |dropdown|
+    }}
+      {{#dropdown.trigger}}Open me{{/dropdown.trigger}}
+      {{#dropdown.content}}<h3>Content of the dropdown</h3>{{/dropdown.content}}
+    {{/basic-dropdown}}
+  `);
+
+  // TODO: @jewilkin - surely there's a cleaner way to do this, but this.element and
+  // this.get('element') return undefined here
+  let [$dropdown] = this.$('.ember-basic-dropdown');
+
+  run(() => {
+    let event = new window.Event('focusin', { bubbles: true, cancelable: true, view: window });
+    $dropdown.dispatchEvent(event);
+  });
+});
+
+test('If it receives an `onFocusOut` action, it will be invoked when a focusout event is received', function(assert) {
+  assert.expect(1);
+
+  let userSuppliedAction = (dropdown, e) => {
+    assert.ok(e instanceof window.Event, 'It receives the event as second argument');
+  };
+  this.set('onFocusOut', userSuppliedAction);
+
+  this.render(hbs`
+    {{#basic-dropdown
+      onFocusOut=onFocusOut
+      renderInPlace=true
+      as |dropdown|
+    }}
+      {{#dropdown.trigger}}Open me{{/dropdown.trigger}}
+      {{#dropdown.content}}<h3>Content of the dropdown</h3>{{/dropdown.content}}
+    {{/basic-dropdown}}
+  `);
+
+  // TODO: @jewilkin - surely there's a cleaner way to do this, but this.element and
+  // this.get('element') return undefined here
+  let [$dropdown] = this.$('.ember-basic-dropdown');
+
+  run(() => {
+    let event = new window.Event('focusout', { bubbles: true, cancelable: true, view: window });
+    $dropdown.dispatchEvent(event);
+  });
+});
+
 // test('BUGFIX: When clicking in the trigger text selection is disabled until the user raises the finger', function(assert) {
 //   assert.expect(2);
 

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -486,3 +486,77 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
   run(() => input.focus());
 });
 
+// Override click toggle trigger
+test('Allows overriding the default mouseDown `toggle` action with user-supplied action', function(assert) {
+  assert.expect(4);
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {}
+    }
+  };
+
+  let userSuppliedAction = function(dropdown, e) {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    assert.ok(e instanceof window.Event, 'It receives the event');
+    assert.equal(arguments.length, 2, 'It receives two arguments');
+    assert.equal(dropdown, this.dropdown, 'It receives the dropdown configuration object');
+  };
+
+  this.set('onMousedownOverride', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onMousedownOverride=onMousedownOverride dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+  `);
+  clickTrigger();
+});
+
+// Override keydown toggle trigger
+test('Allows overriding the default mouseDown `toggle` action with user-supplied action', function(assert) {
+  assert.expect(4);
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {}
+    }
+  };
+
+  let userSuppliedAction = function(dropdown, e) {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    assert.ok(e instanceof window.Event, 'It receives the event');
+    assert.equal(arguments.length, 2, 'It receives two arguments');
+    assert.equal(dropdown, this.dropdown, 'It receives the dropdown configuration object');
+  };
+
+  this.set('onKeydownOverride', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onKeydownOverride=onKeydownOverride dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
+  `);
+  fireKeydown('.ember-basic-dropdown-trigger', 70);
+});
+
+// Override keydown toggle trigger
+test('Allows overriding the default mouseDown `toggle` action with user-supplied action', function(assert) {
+  assert.expect(4);
+
+  this.dropdown = {
+    uniqueId: 123,
+    actions: {
+      toggle: () => {}
+    }
+  };
+
+  let userSuppliedAction = function(dropdown, e) {
+    assert.ok(true, 'The `userSuppliedAction()` action has been fired');
+    assert.ok(e instanceof window.Event, 'It receives the event');
+    assert.equal(arguments.length, 2, 'It receives two arguments');
+    assert.equal(dropdown, this.dropdown, 'It receives the dropdown configuration object');
+  };
+
+  this.set('onTouchendOverride', userSuppliedAction);
+  this.render(hbs`
+    {{#basic-dropdown/trigger onTouchendOverride=onTouchendOverride dropdown=dropdown isTouchDevice=true}}Click me{{/basic-dropdown/trigger}}
+  `);
+  tapTrigger();
+});


### PR DESCRIPTION
(Builds on earlier pull request: https://github.com/cibernox/ember-basic-dropdown/pull/192 )

Add support for mouseenter/mouseleave and focusin/focusout events at the dropdown container level. Rationale is that we frequently do not want to close the dropdown (for example) when we hover off of the dropdown.trigger element onto the dropdown.content element.

This retains the optional event handlers on the dropdown.trigger to ensure compatibility.

Thanks again for the helpful project!