### PR TITLE
Remove `aria-pressed` logic. It’s still bound, but doesn’t show by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- [BREAKING] Don't display `aria-pressed` when the component is opened. The attribute is not
+  present by default, but can be bound from the outside.
 - [BREAKING] Don't display `aria-haspopup` by default, but display it if passed in a truthy value.
 - [BREAKING] Use `aria-owns` instead of `aria-controls` to link trigger and content together.
 

--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -68,7 +68,7 @@ export default Component.extend({
   'aria-disabled': trueStringIfPresent('dropdown.disabled'),
   'aria-expanded': trueStringIfPresent('dropdown.isOpen'),
   'aria-invalid': trueStringIfPresent('ariaInvalid'),
-  'aria-pressed': trueStringIfPresent('dropdown.isOpen'),
+  'aria-pressed': trueStringIfPresent('ariaPressed'),
   'aria-required': trueStringIfPresent('ariaRequired'),
 
   tabIndex: computed('dropdown.disabled', 'tabindex', function() {

--- a/tests/dummy/app/styles/components/main-header.scss
+++ b/tests/dummy/app/styles/components/main-header.scss
@@ -37,7 +37,7 @@
   &:hover {
     /* more styles in brandification */
   }
-  &[aria-pressed=true] {
+  &[aria-expanded=true] {
     box-shadow: inset 0 3px 5px rgba(0,0,0,0.125);
     transform: translateY(3px);
   }

--- a/tests/dummy/app/styles/demos/content-mouse-enter-leave.scss
+++ b/tests/dummy/app/styles/demos/content-mouse-enter-leave.scss
@@ -28,7 +28,7 @@
     padding: 5px 10px;
     cursor: pointer;
     height: 30px;
-    &:focus, &[aria-pressed=true] {
+    &:focus, &[aria-expanded=true] {
       outline: none;
       background-color: #1b94ef;
     }

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -177,16 +177,21 @@ test('If the received dropdown is open, it has an `aria-expanded="true"` attribu
   assert.equal($trigger.attr('aria-expanded'), 'true', 'the aria-expanded is true');
 });
 
-test('If the received dropdown is open, it has an `aria-pressed="true"` attribute', function(assert) {
-  assert.expect(2);
+test('The `ariaPressed` attribute is bound, but defaults to false', function(assert) {
+  assert.expect(3);
   this.dropdown = { uniqueId: 123, isOpen: false };
   this.render(hbs`
     {{#basic-dropdown/trigger dropdown=dropdown}}Click me{{/basic-dropdown/trigger}}
   `);
   let $trigger = this.$('.ember-basic-dropdown-trigger');
-  assert.equal($trigger.attr('aria-pressed'), undefined, 'the aria-pressed is false');
+  assert.equal($trigger.attr('aria-pressed'), undefined, 'the aria-pressed is not present');
   run(() => set(this.dropdown, 'isOpen', true));
-  assert.equal($trigger.attr('aria-pressed'), 'true', 'the aria-pressed is true');
+  assert.equal($trigger.attr('aria-pressed'), undefined, 'the aria-pressed is not present');
+  this.render(hbs`
+    {{#basic-dropdown/trigger dropdown=dropdown ariaPressed=true}}Click me{{/basic-dropdown/trigger}}
+  `);
+  $trigger = this.$('.ember-basic-dropdown-trigger');
+  assert.equal($trigger.attr('aria-pressed'), 'true', 'the aria-pressed is not present');
 });
 
 test('If it has an `aria-owns="foo123"` attribute pointing to the id of the content', function(assert) {


### PR DESCRIPTION
Part of #218