### PR TITLE
Have a constant element in DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- [BREAKING] It is a problem for a11y to have `aria-owns/controls` to an element that it's not
+  in the DOM, so now there is a stable div with the right ID that gets moved to the root 
+  of the body when the component opens.
 - [BUGFIX] Fix `clickDropdown` test helper when the given selector is already the selector
   of the trigger.
 

--- a/addon/templates/components/basic-dropdown/content.hbs
+++ b/addon/templates/components/basic-dropdown/content.hbs
@@ -12,5 +12,5 @@
     </div>
   {{/ember-wormhole}}
 {{else}}
-  <div id={{dropdownId}} style="display: none;"></div>
+  <div id={{dropdownId}} class="ember-basic-dropdown-content-placeholder" style="display: none;"></div>
 {{/if}}

--- a/addon/templates/components/basic-dropdown/content.hbs
+++ b/addon/templates/components/basic-dropdown/content.hbs
@@ -11,4 +11,6 @@
       {{yield}}
     </div>
   {{/ember-wormhole}}
+{{else}}
+  <div id={{dropdownId}} style="display: none;"></div>
 {{/if}}


### PR DESCRIPTION
Part of #218 

/cc @steveszc can you verify that this makes a difference and the fact the the div moves from beneath the input to the root of the body is not a problem? Render the div in the wormhole has a couple issues. Because it some glimmer2 limitations having an IF right inside an ember-wormhole, without a stable parent, causes a render problem (well know issue).