### PR TITLE
[BUGFIX] Fix `clickDropdown` test helper to work when the given selector already belongs the trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- [BUGFIX] Fix `clickDropdown` test helper when the given selector is already the selector
+  of the trigger.
+
 # 0.23.0
 - [BREAKING] Don't display `aria-pressed` when the component is opened. The attribute is not
   present by default, but can be bound from the outside.

--- a/test-support/helpers/ember-basic-dropdown.js
+++ b/test-support/helpers/ember-basic-dropdown.js
@@ -44,7 +44,9 @@ export function clickTrigger(scope, options = {}) {
   let selector = '.ember-basic-dropdown-trigger';
   if (scope) {
     let $element = $(scope);
-    if (!$element.hasClass('ember-basic-dropdown-trigger')) {
+    if ($element.hasClass('ember-basic-dropdown-trigger')) {
+      selector = scope;
+    } else {
       selector = scope + ' ' + selector;
     }
   }

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -13,6 +13,7 @@ test('`clickDropdown` simulates a click in the dropdown WITHIN the given selecto
 
   andThen(function() {
     assert.equal(find('.ember-basic-dropdown-content').length, 1, 'There is a dropdown open');
+    assert.equal(find('.ember-basic-dropdown-content').text().trim(), 'Hello world 1!', 'There it is the expected one');
   });
 });
 
@@ -26,5 +27,6 @@ test('`clickDropdown` simulates a click in the dropdown WITH the given selector'
 
   andThen(function() {
     assert.equal(find('.ember-basic-dropdown-content').length, 1, 'There is a dropdown open');
+    assert.equal(find('.ember-basic-dropdown-content').text().trim(), 'Hello world 1!', 'There it is the expected one');
   });
 });

--- a/tests/dummy/app/templates/helpers-testing.hbs
+++ b/tests/dummy/app/templates/helpers-testing.hbs
@@ -1,12 +1,23 @@
 <h1>Helpers testing</h1>
 
+<div class="dropdown-0-wrapper">
+  {{#basic-dropdown selected=selected1 onSelect=(action (mut selected1) value="date") as |dd|}}
+    {{#dd.trigger class="dropdown-0"}}
+      Click me
+    {{/dd.trigger}}
+    {{#dd.content}}
+      Hello world 0!
+    {{/dd.content}}
+  {{/basic-dropdown}}
+</div>
+
 <div class="dropdown-1-wrapper">
   {{#basic-dropdown selected=selected1 onSelect=(action (mut selected1) value="date") as |dd|}}
     {{#dd.trigger class="dropdown-1"}}
       Click me
     {{/dd.trigger}}
     {{#dd.content}}
-      Hello world!
+      Hello world 1!
     {{/dd.content}}
   {{/basic-dropdown}}
 </div>


### PR DESCRIPTION
This will be backported to 0.22.X