### PR TITLE
Fix touch handler synthetic click

### DIFF
--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -148,7 +148,7 @@ export default Component.extend({
       // to simulate natural behaviour.
       e.target.focus();
       setTimeout(function() {
-        e.target.click();
+        $(e.target).click();
       }, 0);
       e.preventDefault();
     },

--- a/test-support/helpers/ember-basic-dropdown.js
+++ b/test-support/helpers/ember-basic-dropdown.js
@@ -63,7 +63,7 @@ export function clickTrigger(scope, options = {}) {
 }
 
 export function tapTrigger(scope, options = {}) {
-  let selector = `.ember-basic-dropdown-trigger ${options.triggerChildSelector || ''}`.trim();
+  let selector = '.ember-basic-dropdown-trigger';
   if (scope) {
     selector = scope + ' ' + selector;
   }

--- a/test-support/helpers/ember-basic-dropdown.js
+++ b/test-support/helpers/ember-basic-dropdown.js
@@ -63,7 +63,7 @@ export function clickTrigger(scope, options = {}) {
 }
 
 export function tapTrigger(scope, options = {}) {
-  let selector = '.ember-basic-dropdown-trigger';
+  let selector = `.ember-basic-dropdown-trigger ${options.triggerChildSelector || ''}`.trim();
   if (scope) {
     selector = scope + ' ' + selector;
   }

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { clickTrigger, tapTrigger, fireKeydown } from '../../../helpers/ember-basic-dropdown';
+import { clickTrigger, tapTrigger, fireKeydown, nativeTap } from '../../../helpers/ember-basic-dropdown';
 import run from 'ember-runloop';
 import set from 'ember-metal/set';
 
@@ -702,5 +702,5 @@ test('Tapping an SVG inside of the trigger invokes the toggle action on the drop
   this.render(hbs`
     {{#basic-dropdown/trigger dropdown=dropdown isTouchDevice=true}}<svg class="trigger-child-svg">Click me</svg>{{/basic-dropdown/trigger}}
   `);
-  tapTrigger('', {triggerChildSelector: '.trigger-child-svg'});
+  nativeTap('.trigger-child-svg');
 });

--- a/tests/integration/components/basic-dropdown/trigger-test.js
+++ b/tests/integration/components/basic-dropdown/trigger-test.js
@@ -687,3 +687,20 @@ test('A user-supplied onKeyDown action, returning `false`, will prevent the defa
   `);
   fireKeydown('.ember-basic-dropdown-trigger', 13); // Enter
 });
+
+test('Tapping an SVG inside of the trigger invokes the toggle action on the dropdown', function(assert) {
+  assert.expect(2);
+  this.dropdown = {
+    actions: {
+      uniqueId: 123,
+      toggle(e) {
+        assert.ok(true, 'The `toggle()` action has been fired');
+        assert.ok(e instanceof window.Event && arguments.length === 1, 'It receives the event as first and only argument');
+      }
+    }
+  };
+  this.render(hbs`
+    {{#basic-dropdown/trigger dropdown=dropdown isTouchDevice=true}}<svg class="trigger-child-svg">Click me</svg>{{/basic-dropdown/trigger}}
+  `);
+  tapTrigger('', {triggerChildSelector: '.trigger-child-svg'});
+});


### PR DESCRIPTION
If `e.target` is an SVG element `click()` method doesn't exist. jQuery takes care of that.