### PR TITLE
[Fixes #231] Move ember-native-dom-helpers to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "ember-font-awesome": "^3.0.2",
     "ember-href-to": "1.11.0",
     "ember-load-initializers": "^0.6.0",
-    "ember-native-dom-helpers": "^0.1.3",
     "ember-pagefront": "0.11.2",
     "ember-resolver": "^2.0.3",
     "ember-source": "^2.12.0-beta.1",
@@ -66,6 +65,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.10",
     "ember-cli-htmlbars": "^1.1.1",
+    "ember-native-dom-helpers": "^0.1.3",
     "ember-wormhole": "^0.5.1"
   },
   "ember-addon": {


### PR DESCRIPTION
I verified this causes ember-native-dom-helpers to be added to node_modules in my app.