### PR TITLE
Fix calculation of position to take scroll bars into account

### DIFF
--- a/addon/utils/calculate-position.js
+++ b/addon/utils/calculate-position.js
@@ -29,7 +29,7 @@ export function calculateWormholedPosition(trigger, content, { horizontalPositio
   let scroll = { left: window.pageXOffset, top: window.pageYOffset };
   let { left: triggerLeft, top: triggerTop, width: triggerWidth, height: triggerHeight } = trigger.getBoundingClientRect();
   let { height: dropdownHeight, width: dropdownWidth } = content.getBoundingClientRect();
-  let viewportWidth = self.window.innerWidth;
+  let viewportWidth = self.document.body.clientWidth || self.window.innerWidth;
   let style = {};
 
   // Calculate drop down width


### PR DESCRIPTION
This fixes https://github.com/cibernox/ember-basic-dropdown/issues/262, by using `document.body.clientWidth` instead of `window.innerWidth` to calculate the screen width.