### PR TITLE
fix(ember-cli-build): include Babel polyfill

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let project = defaults.project;
   let options = {
+    'ember-cli-babel': {
+      includePolyfill: true
+    },
     snippetPaths: ['tests/dummy/app/templates/snippets']
   };
 


### PR DESCRIPTION
closes #274 

Tells ember-cli-babel to [load the polyfill](https://github.com/babel/ember-cli-babel#polyfill)