### PR TITLE
[BREAKING] Introduce `destination=`. Deprecate `to`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- [BREAKING] Passing `to="id-of-elmnt"` to the `{{#dropdown.content}}` component is deprecated.
+  The way to specify a different destination for `ember-wormhole` is now by passing `destination=id-of-elmnt`
+  to the top-level `{{#basic-dropdown}}` component. The old method works but shows a deprecation message.
+
 # 0.31.5
 - [INTERNAL] Update ember-concurrency to a version that uses babel 6.
 

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -5,7 +5,8 @@ import layout from '../templates/components/basic-dropdown';
 import { join } from 'ember-runloop';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 import calculatePosition from '../utils/calculate-position';
-const { guidFor } = Ember;
+import computed from 'ember-computed';
+const { guidFor, testing, getOwner } = Ember;
 
 const assign = Object.assign || function EmberAssign(original, ...args) {
   for (let i = 0; i < args.length; i++) {
@@ -87,6 +88,16 @@ export default Component.extend({
       registerAPI(null);
     }
   },
+
+  // CPs
+  destination: computed({
+    get() {
+      return this._getDestinationId();
+    },
+    set(_, v) {
+      return v === undefined ? this._getDestinationId() : v;
+    }
+  }),
 
   // Actions
   actions: {
@@ -225,5 +236,13 @@ export default Component.extend({
       registerAPI(newState);
     }
     return newState;
+  },
+
+  _getDestinationId() {
+    if (testing) {
+      return 'ember-testing';
+    }
+    let config = getOwner(this).resolveRegistration('config:environment');
+    return config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole';
   }
 });

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -12,7 +12,7 @@ function closestContent(el) {
   }
   return el;
 }
-const { testing, getOwner } = Ember;
+const { testing } = Ember;
 const MutObserver = self.window.MutationObserver || self.window.WebKitMutationObserver;
 const rAF = self.window.requestAnimationFrame || function(cb) {
   cb();
@@ -80,11 +80,12 @@ export default Component.extend({
   },
 
   // CPs
-  to: computed({
+  to: computed('destination', {
     get() {
-      return this._getDestinationId();
+      return this.get('destination');
     },
     set(_, v) {
+      Ember.deprecate('Passing `to="id-of-elmnt"` to the {{#dropdown.content}} has been deprecated. Please pass `destination="id-of-elmnt"` to the {{#basic-dropdown}} component instead', false, { id: 'ember-basic-dropdown-to-in-content', until: '0.40' });
       return v === undefined ? this._getDestinationId() : v;
     }
   }),
@@ -257,13 +258,5 @@ export default Component.extend({
       self.document.body.removeEventListener('touchstart', this.touchStartHandler, true);
       self.document.body.removeEventListener('touchend', this.handleRootMouseDown, true);
     }
-  },
-
-  _getDestinationId() {
-    if (testing) {
-      return 'ember-testing';
-    }
-    let config = getOwner(this).resolveRegistration('config:environment');
-    return config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole';
   }
 });

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -15,6 +15,7 @@
     hPosition=(readonly hPosition)
     renderInPlace=(readonly renderInPlace)
     vPosition=(readonly vPosition)
+    destination=(readonly destination)
     top=(readonly top)
     left=(readonly left)
     right=(readonly right)

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -34,6 +34,11 @@
       <td>Another way of providing a class to the component without polluting the <code>class</code> attribute. Useful in contextual component to allow users give their own classes while still retaining some defaults</td>
     </tr>
     <tr>
+      <td>destination</td>
+      <td>String</td>
+      <td>The selector of a DOM element where the dropdown will be rendered using ember-wormhole</td>
+    </tr>
+    <tr>
       <td>contentComponent</td>
       <td><code>String or Component</code></td>
       <td>The component to rended as content instead of the default content component. You <em>probably</em> don't want to use this option.</td>
@@ -204,7 +209,7 @@
     <tr>
       <td>to</td>
       <td>String</td>
-      <td>The selector of a DOM element where the dropdown will be rendered using ember-wormhole</td>
+      <td><strong>[DEPRECATED]</strong>The selector of a DOM element where the dropdown will be rendered using ember-wormhole</td>
     </tr>
     <tr>
       <td>onFocusIn</td>

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -393,6 +393,21 @@ test('If the component\'s `disabled` property changes, the `registerAPI` action 
   assert.notOk(find('#is-disabled'), 'The select is enabled again');
 });
 
+test('It can receive `destination=id-of-elmnt` to customize where ember-wormhole is going to render the content', async function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#basic-dropdown destination="id-of-elmnt" as |dd|}}
+      {{#dd.trigger}}Click me{{/dd.trigger}}
+      {{#dd.content}}Hello{{/dd.content}}
+    {{/basic-dropdown}}
+    <div id="id-of-elmnt"></div>
+  `);
+
+  await clickTrigger();
+  assert.equal(find('.ember-basic-dropdown-content').parentNode.id, 'id-of-elmnt', 'The content has been rendered in an alternative destination');
+});
+
 // A11y
 test('By default, the `aria-owns` attribute of the trigger contains the id of the content', async function(assert) {
   assert.expect(1);

--- a/tests/integration/components/basic-dropdown/content-test.js
+++ b/tests/integration/components/basic-dropdown/content-test.js
@@ -12,7 +12,7 @@ test('If the dropdown is open renders the given block in a div with class `ember
   assert.expect(2);
   this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let content = find('.ember-basic-dropdown-content');
   assert.equal(content.textContent.trim(), 'Lorem ipsum', 'It contains the given block');
@@ -23,7 +23,7 @@ test('If the dropdown is closed, nothing is rendered', function(assert) {
   assert.expect(1);
   this.dropdown = { uniqueId: 'e123', isOpen: false };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   assert.notOk(find('.ember-basic-dropdown-content'), 'Nothing is rendered');
 });
@@ -40,7 +40,7 @@ test('If it receives `renderInPlace=true`, it is rendered right here instead of 
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown renderInPlace=true}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' renderInPlace=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let content = find('.ember-basic-dropdown-content');
   assert.ok(content, 'It is rendered in the spot');
@@ -52,7 +52,7 @@ test('If it receives `to="foo123"`, it is rendered in the element with that ID',
   this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
     <div id="foo123"></div>
-    {{#basic-dropdown/content dropdown=dropdown to="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' to="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   let content = find('#foo123 .ember-basic-dropdown-content');
   assert.ok(content, 'It is rendered');
@@ -63,7 +63,7 @@ test('It derives the ID of the content from the `uniqueId` property of of the dr
   assert.expect(1);
   this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   assert.equal(find('.ember-basic-dropdown-content').id, 'ember-basic-dropdown-content-e123', 'contains the expected ID');
 });
@@ -72,7 +72,7 @@ test('If it receives `class="foo123"`, the rendered content will have that class
   assert.expect(1);
   this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown class="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' class="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   assert.ok(find('.ember-basic-dropdown-content.foo123'), 'The dropdown contains that class');
 });
@@ -81,7 +81,7 @@ test('If it receives `defaultClass="foo123"`, the rendered content will have tha
   assert.expect(1);
   this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown defaultClass="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' defaultClass="foo123"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   assert.ok(find('.ember-basic-dropdown-content.foo123'), 'The dropdown contains that class');
 });
@@ -90,7 +90,7 @@ test('If it receives `dir="rtl"`, the rendered content will have the attribute s
   assert.expect(1);
   this.dropdown = { isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown dir="rtl"}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' dir="rtl"}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   assert.equal(find('.ember-basic-dropdown-content').attributes.dir.value, 'rtl', 'The dropdown has `dir="rtl"`');
 });
@@ -110,7 +110,7 @@ test('Clicking anywhere in the app outside the component will invoke the close a
   };
   this.render(hbs`
     <div id="other-div"></div>
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 
   click('#other-div');
@@ -129,7 +129,7 @@ test('Clicking anywhere inside the dropdown content doesn\'t invoke the close ac
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}<div id="inside-div">Lorem ipsum</div>{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}<div id="inside-div">Lorem ipsum</div>{{/basic-dropdown/content}}
   `);
   click('#inside-div');
 });
@@ -162,9 +162,9 @@ test('Clicking in inside the a dropdown content nested inside another dropdown c
   };
   this.render(hbs`
     <div id="fake-trigger"></div>
-    {{#basic-dropdown/content dropdown=dropdown1}}
+    {{#basic-dropdown/content dropdown=dropdown1 destination='ember-testing'}}
       Lorem ipsum
-      {{#basic-dropdown/content dropdown=dropdown2 renderInPlace=true}}
+      {{#basic-dropdown/content dropdown=dropdown2 destination='ember-testing' renderInPlace=true}}
         <div id="nested-content-div">dolor sit amet</div>
       {{/basic-dropdown/content}}
     {{/basic-dropdown/content}}
@@ -188,7 +188,7 @@ test('Tapping anywhere in the app outside the component will invoke the close ac
   };
   this.render(hbs`
     <div id="other-div"></div>
-    {{#basic-dropdown/content dropdown=dropdown isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 
   triggerEvent('#other-div', 'touchstart');
@@ -209,7 +209,7 @@ test('Scrolling (touchstart + touchmove + touchend) anywhere in the app outside 
   };
   this.render(hbs`
     <div id="other-div"></div>
-    {{#basic-dropdown/content dropdown=dropdown isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' isTouchDevice=true}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 
   triggerEvent('#other-div', 'touchstart');
@@ -227,7 +227,7 @@ test('If it receives an `onFocusIn` action, it is invoked if a focusin event is 
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown onFocusIn=onFocusIn}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' onFocusIn=onFocusIn}}
       <input type="text" id="test-input-focusin" />
     {{/basic-dropdown/content}}
   `);
@@ -243,7 +243,7 @@ test('If it receives an `onFocusOut` action, it is invoked if a focusout event i
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown onFocusOut=onFocusOut}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' onFocusOut=onFocusOut}}
       <input type="text" id="test-input-focusin" />
     {{/basic-dropdown/content}}
   `);
@@ -262,7 +262,7 @@ test('If it receives an `onMouseEnter` action, it is invoked if a mouseenter eve
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown onMouseEnter=onMouseEnter}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' onMouseEnter=onMouseEnter}}
       Content
     {{/basic-dropdown/content}}
   `);
@@ -278,7 +278,7 @@ test('If it receives an `onMouseLeave` action, it is invoked if a mouseleave eve
     assert.ok(e instanceof window.Event, 'the second argument is an event');
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown onMouseLeave=onMouseLeave}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' onMouseLeave=onMouseLeave}}
       Content
     {{/basic-dropdown/content}}
   `);
@@ -298,7 +298,7 @@ test('The component is repositioned immediatly when opened', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 });
 
@@ -314,7 +314,7 @@ test('The component is not repositioned if it is closed', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
 });
 
@@ -331,7 +331,7 @@ test('The component is repositioned if the window scrolls', function(assert) {
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   run(() => window.dispatchEvent(new window.Event('scroll')));
   assert.equal(repositions, 2, 'The component has been repositioned twice');
@@ -350,7 +350,7 @@ test('The component is repositioned if the window is resized', function(assert) 
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   run(() => window.dispatchEvent(new window.Event('resize')));
   assert.equal(repositions, 2, 'The component has been repositioned twice');
@@ -369,7 +369,7 @@ test('The component is repositioned if the orientation changes', function(assert
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}Lorem ipsum{{/basic-dropdown/content}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}Lorem ipsum{{/basic-dropdown/content}}
   `);
   run(() => window.dispatchEvent(new window.Event('orientationchange')));
   assert.equal(repositions, 2, 'The component has been repositioned twice');
@@ -393,7 +393,7 @@ test('The component is repositioned if the content of the dropdown changs', func
     }
   };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing'}}
       <div id="content-target-div"></div>
     {{/basic-dropdown/content}}
   `);
@@ -409,7 +409,7 @@ test('If it receives an `overlay=true` option, there is an overlay covering all 
   assert.expect(2);
   this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
   this.render(hbs`
-    {{#basic-dropdown/content dropdown=dropdown overlay=true}}
+    {{#basic-dropdown/content dropdown=dropdown destination='ember-testing' overlay=true}}
       <input type="text" id="test-input-focusin" />
     {{/basic-dropdown/content}}
   `);


### PR DESCRIPTION
Passing `to="id-of-elmnt"` to the `{{#dropdown.content}}` component is deprecated.
The way to specify a different destination for `ember-wormhole` is now by passing
`destination=id-of-elmnt` to the top-level `{{#basic-dropdown}}` component.
The old property `to=` still works but shows a deprecation message and will
be removed soon.