### PR TITLE
[PERF] Optimize number of reposition calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- [PERF] Avoid repositioning the content when the window scrolls if the wormhole destination
+  is a direct child of the body (that's the case almost always).
 - [BREAKING/BUGFIX] Closes #233. The positioning logic now accounts for the position of the
   parent of container if it has position relative or absolute. The breaking part is that
   custom `calculatePosition` functions now take the destination element as third arguments,

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -86,7 +86,7 @@ export default Component.extend({
     },
     set(_, v) {
       Ember.deprecate('Passing `to="id-of-elmnt"` to the {{#dropdown.content}} has been deprecated. Please pass `destination="id-of-elmnt"` to the {{#basic-dropdown}} component instead', false, { id: 'ember-basic-dropdown-to-in-content', until: '0.40' });
-      return v === undefined ? this._getDestinationId() : v;
+      return v === undefined ? this.get('destination') : v;
     }
   }),
 
@@ -141,6 +141,7 @@ export default Component.extend({
     }
     let changes = dropdown.actions.reposition();
     if (!this.get('renderInPlace')) {
+      this.destinationElement = document.getElementById(this.get('destination'));
       this.addGlobalEvents();
       this.startObservingDomMutations();
     } else if (changes.vPosition === 'above') {
@@ -181,7 +182,9 @@ export default Component.extend({
   },
 
   addGlobalEvents() {
-    self.window.addEventListener('scroll', this.runloopAwareReposition);
+    if (this.destinationElement.parentNode.tagName !== 'BODY') {
+      self.window.addEventListener('scroll', this.runloopAwareReposition);
+    }
     self.window.addEventListener('resize', this.runloopAwareReposition);
     self.window.addEventListener('orientationchange', this.runloopAwareReposition);
   },
@@ -252,6 +255,7 @@ export default Component.extend({
 
   _teardown() {
     this.removeGlobalEvents();
+    this.destinationElement = null;
     this.stopObservingDomMutations();
     self.document.body.removeEventListener('mousedown', this.handleRootMouseDown, true);
     if (this.get('isTouchDevice')) {

--- a/tests/dummy/app/styles/_base.scss
+++ b/tests/dummy/app/styles/_base.scss
@@ -16,6 +16,8 @@ html {
 
 body {
   color: $text-color;
+  // position: relative;
+  // margin-top: 60px;
 }
 
 a {


### PR DESCRIPTION
If the wormhole destination is a direct child of the BODY element, there
is no need to reposition it after every scroll event, since the origin
of coordinates is the scrollable element itself.

This is the case for almost every dropdown. That method, albeit fast, can be called tens of times per second, so I expect this to matter quite a lot.