### PR TITLE
Handle undefined positioning when the dropdown is opened and closed at the same time

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -91,7 +91,8 @@ export default Component.extend({
     this._super(...arguments);
     let oldDropdown = this.get('oldDropdown') || {};
     let dropdown = this.get('dropdown');
-    if (!oldDropdown.isOpen && dropdown.isOpen) {
+    let {top, left, right} = this.getProperties('top', 'left', 'right');
+    if ((!oldDropdown.isOpen || (top === null && left === null && right === null)) && dropdown.isOpen) {
       scheduleOnce('afterRender', this, this.open);
     } else if (oldDropdown.isOpen && !dropdown.isOpen) {
       this.close();

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -91,6 +91,10 @@ export default Component.extend({
     this._super(...arguments);
     let oldDropdown = this.get('oldDropdown') || {};
     let dropdown = this.get('dropdown');
+
+    // The following condition checks whether we need to open the dropdown - either because it was
+    // closed and is now open or because it was open and then it was closed and opened pretty much at
+    // the same time, indicated by `top`, `left` and `right` being null.
     let {top, left, right} = this.getProperties('top', 'left', 'right');
     if ((!oldDropdown.isOpen || (top === null && left === null && right === null)) && dropdown.isOpen) {
       scheduleOnce('afterRender', this, this.open);


### PR DESCRIPTION
This is the simple fix I mentioned in https://github.com/cibernox/ember-power-select/issues/788. It should work for the case I presented in [this comment](https://github.com/cibernox/ember-power-select/issues/788#issuecomment-301711808).

Unfortunately, I was unable to make a test case for this, as it seems almost impossible to replicate the sort of user interaction required to trigger the bug.