### PR TITLE
Fix mobile Firefox issue with invoking the click event

### DIFF
--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -168,8 +168,7 @@ export default Component.extend({
       // to simulate natural behaviour.
       e.target.focus();
       setTimeout(function() {
-        let event = document.createEvent('MouseEvents');
-        event.initMouseEvent('click', true, true, window)
+        let event = new Event('click');
         e.target.dispatchEvent(event);
       }, 0);
       e.preventDefault();

--- a/addon/components/basic-dropdown/trigger.js
+++ b/addon/components/basic-dropdown/trigger.js
@@ -168,8 +168,15 @@ export default Component.extend({
       // to simulate natural behaviour.
       e.target.focus();
       setTimeout(function() {
-        let event = new Event('click');
-        e.target.dispatchEvent(event);
+        let event;
+        try {
+          event = document.createEvent('MouseEvents');
+          event.initMouseEvent('click', true, true, window);
+        } catch (e) {
+          event = new Event('click');
+        } finally {
+          e.target.dispatchEvent(event);
+        }
       }, 0);
       e.preventDefault();
     },


### PR DESCRIPTION
Investigated because I was receiving tons of `Not enough arguments to MouseEvent.initMouseEvent` in production from mobile Android Firefox browsers and stumbled on this: 
https://stackoverflow.com/questions/26761625/not-enough-arguments-to-mouseevent-initmouseevent?answertab=active#tab-top