### PR TITLE
fixed a bug when el is document and doesn't have classList

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -9,7 +9,7 @@ import fallbackIfUndefined from '../../utils/computed-fallback-if-undefined';
 import { getScrollParent } from '../../utils/calculate-position';
 
 function closestContent(el) {
-  while (el && !el.classList.contains('ember-basic-dropdown-content')) {
+  while (el && (!el.classList || !el.classList.contains('ember-basic-dropdown-content'))) {
     el = el.parentElement;
   }
   return el;
@@ -306,4 +306,3 @@ export default Component.extend({
     }
   }
 });
-


### PR DESCRIPTION
this fixed:
when dropdown is open and clicking on the scrollbar on page, a JS error is generated:
![screen shot 2017-07-19 at 10 22 54 am](https://user-images.githubusercontent.com/5381429/28371912-4ace54b2-6c6c-11e7-9d43-3badba002b3c.png)

