### PR TITLE
Add removal of IE10 support to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 # 0.33.6
 - [BUGFIX] Prevent dropdowns with `renderInPlace=true` from being incorrectly opened twice. This had
   no evident effects, but lead to the events in the `dd.content` component to be added twice.
+- [BREAKING] Remove support for IE9/IE10.
 
 # 0.33.5
 - [ENHANCEMENT] Allow `transitioningInClass` and `transitioningOutClass` to be several classes by

--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ Check the example in the [Ember Power Select documentation](http://www.ember-pow
 
 This component is smart about where to position the dropdown. It will detect the best place to render
 it based on the space around the trigger, and also will take care of reposition if if the screen is
-resized, scrolled, the device changes it orientation or the content of the dropdown changes
-(implemented with MutationObservers in modern browsers with fallback to DOM events in IE 9/10).
+resized, scrolled, the device changes it orientation or the content of the dropdown changes.
 
 You can force the component to be fixed in one position by passing `verticalPosition = above | below` and/or `horizontalPosition = right | center | left`.
 


### PR DESCRIPTION
I got a little lost down a rabbithole due to IE10 compatibility being dropped in a patch release, hopefully this helps others.

It might also be worth adding a note to lock to 0.33.5 for IE10 compat in the README?