### PR TITLE
Prevent scrolling as an option.

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -263,8 +263,10 @@ export default Component.extend({
   wheelHandler(event) {
     const element = this.dropdownElement;
     if (element.contains(event.target) || element === event.target) {
+      // Discover the amount of scrollable canvas that is within the dropdown.
       const availableScroll = getAvailableScroll(event.target, element);
 
+      // Calculate what the event's desired change to that scrollable canvas is.
       let deltaX, deltaY;
       if (event.deltaMode === 0) {
         // DOM_DELTA_PIXEL: applies almost everywhere.
@@ -274,7 +276,8 @@ export default Component.extend({
         // Reference: https://stackoverflow.com/a/37474225
         // DOM_DELTA_LINE: only applies to Firefox on Windows using a mouse.
         // DOM_DELTA_PAGE: only applies to Firefox on Windows using a mouse with custom settings.
-        // Force to line mode, 3 lines at a time.
+
+        // Force DOM_DELTA_PAGE to line mode, 3 lines at a time.
         const scrollLineHeight = getScrollLineHeight();
         if (event.deltaMode === 2) {
           deltaX = 3;
@@ -285,23 +288,29 @@ export default Component.extend({
         deltaY = event.deltaY * scrollLineHeight;
       }
 
-      if (event.deltaX < availableScroll.deltaXNegative) {
+      // If the consequence of the wheel action would result in scrolling beyond
+      // the scrollable canvas of the dropdown, call preventDefault() and clamp
+      // the value of the delta to the available scroll size.
+      if (deltaX < availableScroll.deltaXNegative) {
         deltaX = availableScroll.deltaXNegative;
         event.preventDefault();
-      } else if (event.deltaX > availableScroll.deltaXPositive) {
+      } else if (deltaX > availableScroll.deltaXPositive) {
         deltaX = availableScroll.deltaXPositive;
         event.preventDefault();
-      } else if (event.deltaY < availableScroll.deltaYNegative) {
+      } else if (deltaY < availableScroll.deltaYNegative) {
         deltaY = availableScroll.deltaYNegative;
         event.preventDefault();
-      } else if (event.deltaY > availableScroll.deltaYPositive) {
+      } else if (deltaY > availableScroll.deltaYPositive) {
         deltaY = availableScroll.deltaYPositive;
         event.preventDefault();
       }
 
-      // This adds back in default behavior for the two good states that the above code breaks.
+      // Add back in the default behavior for the two good states that the above
+      // `preventDefault()` code will break.
       // - Two-axis scrolling on a one-axis scroll container
-      // - The last relevant wheel event if overshooting
+      // - The last relevant wheel event if the scroll is overshooting
+
+      // Also, don't attempt to do this if both of `deltaX` or `deltaY` are 0.
       if (event.defaultPrevented && (deltaX || deltaY)) {
         distributeScroll(deltaX, deltaY, event.target, element);
       }
@@ -334,9 +343,12 @@ export default Component.extend({
     }
   },
 
-  // Assigned at runtime to ensure that property changes don't impact outcome.
+  // Assigned at runtime to ensure that changes to the `preventScroll` property
+  // don't result in not cleaning up after ourselves.
   removeScrollHandling() {},
 
+  // These two functions wire up scroll handling if `preventScroll` is true.
+  // These prevent all scrolling that isn't inside of the dropdown.
   addPreventScrollEvent() {
     self.document.addEventListener('wheel', this.wheelHandler, { capture: true, passive: false });
   },
@@ -344,13 +356,14 @@ export default Component.extend({
     self.document.removeEventListener('wheel', this.wheelHandler, { capture: true, passive: false });
   },
 
+  // These two functions wire up scroll handling if `preventScroll` is false.
+  // These trigger reposition of the dropdown.
   addScrollEvents() {
     self.window.addEventListener('scroll', this.runloopAwareReposition);
     this.scrollableAncestors.forEach((el) => {
       el.addEventListener('scroll', this.runloopAwareReposition);
     });
   },
-
   removeScrollEvents() {
     self.window.removeEventListener('scroll', this.runloopAwareReposition);
     this.scrollableAncestors.forEach((el) => {

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -14,6 +14,7 @@
     dropdown=(readonly publicAPI)
     hPosition=(readonly hPosition)
     renderInPlace=(readonly renderInPlace)
+    preventScroll=(readonly preventScroll)
     vPosition=(readonly vPosition)
     destination=(readonly destination)
     top=(readonly top)

--- a/addon/utils/scroll-helpers.js
+++ b/addon/utils/scroll-helpers.js
@@ -1,0 +1,76 @@
+let scrollLineHeight = null;
+export function getScrollLineHeight() {
+  if (!scrollLineHeight) {
+    const iframe = document.createElement('iframe');
+    iframe.src = '#';
+    iframe.style.display = 'none';
+    document.body.appendChild(iframe);
+    const iframeDocument = iframe.contentWindow.document;
+    iframeDocument.open();
+    iframeDocument.write('<!doctype html><html><head></head><body><span>X</span></body></html>');
+    iframeDocument.close();
+    scrollLineHeight = iframeDocument.body.firstElementChild.offsetHeight;
+    document.body.removeChild(iframe);
+  }
+  return scrollLineHeight;
+}
+
+export function getAvailableScroll(element, container) {
+  const availableScroll = {
+    deltaXNegative: 0,
+    deltaXPositive: 0,
+    deltaYNegative: 0,
+    deltaYPositive: 0
+  };
+
+  let scrollLeftMax, scrollTopMax;
+  while (container.contains(element) || container === element) {
+    scrollLeftMax = element.scrollWidth - element.clientWidth;
+    scrollTopMax = element.scrollHeight - element.clientHeight;
+
+    availableScroll.deltaXNegative += -element.scrollLeft
+    availableScroll.deltaXPositive += scrollLeftMax - element.scrollLeft
+    availableScroll.deltaYNegative += -element.scrollTop
+    availableScroll.deltaYPositive += scrollTopMax - element.scrollTop
+    element = element.parentNode;
+  }
+
+  return availableScroll;
+}
+
+// Recursively walks up scroll containers until the delta is distributed or we
+// run out of elements in the allowed-to-scroll container.
+export function distributeScroll(deltaX, deltaY, element, container) {
+  const scrollLeftMax = element.scrollWidth - element.clientWidth;
+  const scrollTopMax = element.scrollHeight - element.clientHeight;
+
+  const availableScroll = {
+    deltaXNegative: -element.scrollLeft,
+    deltaXPositive: scrollLeftMax - element.scrollLeft,
+    deltaYNegative: -element.scrollTop,
+    deltaYPositive: scrollTopMax - element.scrollTop
+  };
+
+  element.scrollLeft = element.scrollLeft + deltaX;
+  element.scrollTop = element.scrollTop + deltaY;
+
+  if (deltaX > availableScroll.deltaXPositive) {
+    deltaX = deltaX - availableScroll.deltaXPositive;
+  } else if (deltaX < availableScroll.deltaXNegative) {
+    deltaX = deltaX - availableScroll.deltaXNegative;
+  } else {
+    deltaX = 0;
+  }
+
+  if (deltaY > availableScroll.deltaYPositive) {
+    deltaY = deltaY - availableScroll.deltaYPositive;
+  } else if (deltaY < availableScroll.deltaYNegative) {
+    deltaY = deltaY - availableScroll.deltaYNegative;
+  } else {
+    deltaY = 0;
+  }
+
+  if (element !== container && (deltaX || deltaY)) {
+    distributeScroll(deltaX, deltaY, element.parentNode, container);
+  }
+}

--- a/addon/utils/scroll-helpers.js
+++ b/addon/utils/scroll-helpers.js
@@ -3,7 +3,11 @@ export function getScrollLineHeight() {
   if (!scrollLineHeight) {
     const iframe = document.createElement('iframe');
     iframe.src = '#';
-    iframe.style.display = 'none';
+    iframe.style.position = 'absolute';
+    iframe.style.visibility = 'hidden';
+    iframe.style.width = '0px';
+    iframe.style.height = '0px';
+    iframe.style.border = 'none';
     document.body.appendChild(iframe);
     const iframeDocument = iframe.contentWindow.document;
     iframeDocument.open();

--- a/app/utils/scroll-helpers.js
+++ b/app/utils/scroll-helpers.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-basic-dropdown/utils/scroll-helpers';

--- a/app/utils/scroll-helpers.js
+++ b/app/utils/scroll-helpers.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-basic-dropdown/utils/scroll-helpers';

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -51,7 +51,12 @@
     <tr>
       <td>matchTriggerWidth</td>
       <td><code>Boolean</code></td>
-      <td>Flag that indicates wether or not the content's width should be equal to the width of the trigger.</td>
+      <td>(Default: <code>false</code>). Flag that indicates whether or not the content's width should be equal to the width of the trigger.</td>
+    </tr>
+    <tr>
+      <td>preventScroll</td>
+      <td><code>Boolean</code></td>
+      <td>(Default: <code>false</code>). Flag that prevents any elements on the page from scrolling. This matches platform-provided <code>select</code> element behavior.</td>
     </tr>
     <tr>
       <td>renderInPlace</td>
@@ -61,7 +66,7 @@
     <tr>
       <td>initiallyOpened</td>
       <td><code>Boolean</code></td>
-      <td>(Default: <code>false</code>). When passed <code>true</code> the component is first rendered open, but other than that it does not alter its behavior: The user can close it as usual.</td>
+      <td>(Default: <code>false</code>). When passed <code>true</code> the component is first rendered open. Used in combination with <code>preventScroll</code> it changes Fastboot user experience, but other than that it does not alter its behavior. The user can close it as usual.</td>
     </tr>
     <tr>
       <td>tagName</td>

--- a/tests/integration/components/basic-dropdown/content-test.js
+++ b/tests/integration/components/basic-dropdown/content-test.js
@@ -319,7 +319,7 @@ module('Integration | Component | basic-dropdown/content', function(hooks) {
   });
 
   test('The component cancels events when preventScroll is true', async function(assert) {
-    assert.expect(2);
+    assert.expect(4);
     this.dropdown = {
       uniqueId: 'e123',
       isOpen: true,
@@ -340,14 +340,20 @@ module('Integration | Component | basic-dropdown/content', function(hooks) {
     `);
 
     let innerScrollable = find('#inner-div');
-    let innerScrollableEvent = new WheelEvent('wheel', { deltaY: -4, cancelable: true, bubbles: true });
+    let innerScrollableEvent = new WheelEvent('wheel', { deltaY: 4, cancelable: true, bubbles: true });
     run(() => innerScrollable.dispatchEvent(innerScrollableEvent));
-    assert.equal(innerScrollableEvent.defaultPrevented, false, 'The inner scrollable does not cancel wheel events.');
+    assert.strictEqual(innerScrollableEvent.defaultPrevented, false, 'The inner scrollable does not cancel wheel events.');
+
+    innerScrollable.scrollTop = 4;
+    let innerScrollableCanceledEvent = new WheelEvent('wheel', { deltaY: -10, cancelable: true, bubbles: true });
+    run(() => innerScrollable.dispatchEvent(innerScrollableCanceledEvent));
+    assert.strictEqual(innerScrollableCanceledEvent.defaultPrevented, true, 'The inner scrollable cancels out of bound wheel events.');
+    assert.strictEqual(innerScrollable.scrollTop, 0, 'The innerScrollable was scrolled anyway.');
 
     let outerScrollable = find('#outer-div');
-    let outerScrollableEvent = new WheelEvent('wheel', { deltaY: -4, cancelable: true, bubbles: true });
+    let outerScrollableEvent = new WheelEvent('wheel', { deltaY: 4, cancelable: true, bubbles: true });
     run(() => outerScrollable.dispatchEvent(outerScrollableEvent));
-    assert.equal(outerScrollableEvent.defaultPrevented, true, 'The outer scrollable cancels wheel events.');
+    assert.strictEqual(outerScrollableEvent.defaultPrevented, true, 'The outer scrollable cancels wheel events.');
   });
 
   test('The component is repositioned if the window scrolls', async function(assert) {

--- a/tests/integration/components/basic-dropdown/content-test.js
+++ b/tests/integration/components/basic-dropdown/content-test.js
@@ -318,6 +318,38 @@ module('Integration | Component | basic-dropdown/content', function(hooks) {
     `);
   });
 
+  test('The component cancels events when preventScroll is true', async function(assert) {
+    assert.expect(2);
+    this.dropdown = {
+      uniqueId: 'e123',
+      isOpen: true,
+      actions: {
+        reposition() {}
+      }
+    };
+
+    await render(hbs`
+      <div id="outer-div" style="width: 100px; height: 100px; overflow: auto;">
+        <div style="width: 200px; height: 200px;">content scroll test</div>
+      </div>
+      {{#basic-dropdown/content preventScroll=true dropdown=dropdown destination='ember-testing'}}
+        <div id="inner-div" style="width: 100px; height: 100px; overflow: auto;">
+          <div style="width: 200px; height: 200px;">content scroll test</div>
+        </div>
+      {{/basic-dropdown/content}}
+    `);
+
+    let innerScrollable = find('#inner-div');
+    let innerScrollableEvent = new WheelEvent('wheel', { deltaY: -4, cancelable: true, bubbles: true });
+    run(() => innerScrollable.dispatchEvent(innerScrollableEvent));
+    assert.equal(innerScrollableEvent.defaultPrevented, false, 'The inner scrollable does not cancel wheel events.');
+
+    let outerScrollable = find('#outer-div');
+    let outerScrollableEvent = new WheelEvent('wheel', { deltaY: -4, cancelable: true, bubbles: true });
+    run(() => outerScrollable.dispatchEvent(outerScrollableEvent));
+    assert.equal(outerScrollableEvent.defaultPrevented, true, 'The outer scrollable cancels wheel events.');
+  });
+
   test('The component is repositioned if the window scrolls', async function(assert) {
     assert.expect(1);
     let repositions = 0;

--- a/tests/unit/utils/scroll-helpers-test.js
+++ b/tests/unit/utils/scroll-helpers-test.js
@@ -1,10 +1,70 @@
-import scrollHelpers from 'dummy/utils/scroll-helpers';
+import { getScrollLineHeight, getAvailableScroll, distributeScroll } from 'ember-basic-dropdown/utils/scroll-helpers';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | scroll helpers');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = scrollHelpers();
-  assert.ok(result);
+test('getScrollLineHeight', function(assert) {
+  // Depends on device and settings.
+  let result = getScrollLineHeight();
+
+  // Also blows up on 0, which is an invalid value.
+  assert.ok(result, 'did not throw errors');
+});
+
+test('getAvailableScroll', function(assert) {
+  const container = document.createElement('div');
+  container.style.height = '100px';
+  container.style.overflow = 'auto';
+  const child = document.createElement('div');
+  child.style.height = '300px';
+  child.style.overflow = 'auto';
+  const grandchild = document.createElement('div');
+  grandchild.style.height = '500px';
+  grandchild.innerText = 'asdf';
+
+  child.appendChild(grandchild);
+  container.appendChild(child);
+  document.body.appendChild(container);
+
+  let result;
+  container.scrollTop = 0;
+  result = getAvailableScroll(child, container);
+  assert.equal(result.deltaYNegative, 0);
+  assert.equal(result.deltaYPositive, 400);
+
+  container.scrollTop = 20;
+  result = getAvailableScroll(child, container);
+  assert.equal(result.deltaYNegative, -20);
+  assert.equal(result.deltaYPositive, 380);
+
+  result = getAvailableScroll(grandchild, container);
+  assert.equal(result.deltaYNegative, -20);
+  assert.equal(result.deltaYPositive, 380);
+});
+
+test('distributeScroll', function(assert) {
+  const container = document.createElement('div');
+  container.style.height = '100px';
+  container.style.overflow = 'auto';
+  const child = document.createElement('div');
+  child.style.height = '300px';
+  child.style.overflow = 'auto';
+  const grandchild = document.createElement('div');
+  grandchild.style.height = '500px';
+  grandchild.innerText = 'asdf';
+
+  child.appendChild(grandchild);
+  container.appendChild(child);
+  document.body.appendChild(container);
+
+  container.scrollTop = 20;
+  child.scrollTop = 20;
+
+  distributeScroll(0, -30, grandchild, container);
+  assert.strictEqual(container.scrollTop, 10);
+  assert.strictEqual(child.scrollTop, 0);
+
+  distributeScroll(0, 40, grandchild, container);
+  assert.strictEqual(container.scrollTop, 10);
+  assert.strictEqual(child.scrollTop, 40);
 });

--- a/tests/unit/utils/scroll-helpers-test.js
+++ b/tests/unit/utils/scroll-helpers-test.js
@@ -1,0 +1,10 @@
+import scrollHelpers from 'dummy/utils/scroll-helpers';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | scroll helpers');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = scrollHelpers();
+  assert.ok(result);
+});


### PR DESCRIPTION
Platform-supplied `select` boxes do not allow scrolling once a `select` is open. This approximates that behavior. (Doesn't work beyond a frame boundary, but works completely within the present `window` context.)