### PR TITLE
Allow string values for positional CSS attributes.

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -8,6 +8,23 @@ import layout from '../templates/components/basic-dropdown';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
 import calculatePosition from '../utils/calculate-position';
 
+/**
+ * If it is a number, it is considered to be in px. If it is a
+ * a String, it is returned as it is.
+ *
+ * @function toCSSValue
+ * @param {Number|String} value value for a CSS property
+ * @returns {String}
+ * @private
+ */
+function toCSSValue(value) {
+  if (typeof value === 'number') {
+    return `${value}px`;
+  } else {
+    return value;
+  }
+}
+
 const assign = Object.assign || function EmberAssign(original, ...args) {
   for (let i = 0; i < args.length; i++) {
     let arg = args[i];
@@ -185,36 +202,32 @@ export default Component.extend({
     };
     if (positions.style) {
       if (positions.style.top !== undefined) {
-        changes.top = `${positions.style.top}px`;
+        changes.top = toCSSValue(positions.style.top);
       }
       // The component can be aligned from the right or from the left, but not from both.
       if (positions.style.left !== undefined) {
-        changes.left = `${positions.style.left}px`;
+        changes.left = toCSSValue(positions.style.left);
         changes.right = null;
         // Since we set the first run manually we may need to unset the `right` property.
         if (positions.style.right !== undefined) {
-          positions.style.right = undefined;
+          positions.style.right = toCSSValue('auto');
         }
       } else if (positions.style.right !== undefined) {
-        changes.right = `${positions.style.right}px`;
-        changes.left = null;
+        changes.right = toCSSValue(positions.style.right);
+        changes.left = toCSSValue('auto');
       }
       if (positions.style.width !== undefined) {
-        changes.width = `${positions.style.width}px`;
+        changes.width = toCSSValue(positions.style.width);
       }
       if (positions.style.height !== undefined) {
-        changes.height = `${positions.style.height}px`;
+        changes.height = toCSSValue(positions.style.height);
       }
       if (this.get('top') === null) {
         // Bypass Ember on the first reposition only to avoid flickering.
         let cssRules = [];
         for (let prop in positions.style) {
           if (positions.style[prop] !== undefined) {
-            if (typeof positions.style[prop] === 'number') {
-              cssRules.push(`${prop}: ${positions.style[prop]}px`)
-            } else {
-              cssRules.push(`${prop}: ${positions.style[prop]}`)
-            }
+            cssRules.push(`${prop}: ${toCSSValue(positions.style[prop])}`);
           }
         }
         dropdown.setAttribute('style', cssRules.join(';'));

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -622,7 +622,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     let dropdownContent = find('.ember-basic-dropdown-content');
     assert.ok(dropdownContent.classList.contains('ember-basic-dropdown-content--above'), 'The dropdown is above');
     assert.ok(dropdownContent.classList.contains('ember-basic-dropdown-content--right'), 'The dropdown is in the right');
-    assert.equal(dropdownContent.attributes.style.value, 'top: 111px;right: 222px;', 'The style attribute is the expected one');
+    assert.equal(dropdownContent.attributes.style.value, 'top: 111px;left: auto;right: 222px;', 'The style attribute is the expected one');
   });
 
   // Customization of inner components


### PR DESCRIPTION
When dealing with complex `calculatePosition` functions,
we may need to use non-numerical values for `top` / `bottom` /
`right` / `left` to overwrite previous values. An example
would be a case where we would have the content vertically
centered to the right side of the trigger (custom numerical
values) but if it does not fit, we would have it `right` and
`below` (no custom values).

The way we can fix this on the custom function is to return
`auto` values for such properties when not needed.

Ember Basic Dropdown would take these values an append `px`
at the end. While this still works, warning were annoying
and still it is not valid for different values.