### PR TITLE
Better scrolling

### DIFF
--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -7,7 +7,11 @@ import { deprecate } from '@ember/debug';
 import layout from '../../templates/components/basic-dropdown/content';
 import fallbackIfUndefined from '../../utils/computed-fallback-if-undefined';
 import { getScrollParent } from '../../utils/calculate-position';
-import { distributeScroll, getAvailableScroll, getScrollLineHeight } from '../../utils/scroll-helpers';
+import {
+  distributeScroll,
+  getAvailableScroll,
+  getScrollDeltas
+} from '../../utils/scroll-helpers';
 
 function closestContent(el) {
   while (el && (!el.classList || !el.classList.contains('ember-basic-dropdown-content'))) {
@@ -266,23 +270,7 @@ export default Component.extend({
       const availableScroll = getAvailableScroll(event.target, element);
 
       // Calculate what the event's desired change to that scrollable canvas is.
-      // DOM_DELTA_PIXEL: applies almost everywhere.
-      let { deltaX, deltaY } = event;
-      if (event.deltaMode !== 0) {
-        // Reference: https://stackoverflow.com/a/37474225
-        // DOM_DELTA_LINE: only applies to Firefox on Windows using a mouse.
-        // DOM_DELTA_PAGE: only applies to Firefox on Windows using a mouse with custom settings.
-
-        // Force DOM_DELTA_PAGE to line mode, 3 lines at a time.
-        const scrollLineHeight = getScrollLineHeight();
-        if (event.deltaMode === 2) {
-          deltaX = 3;
-          deltaY = 3;
-        }
-
-        deltaX = deltaX * scrollLineHeight;
-        deltaY = deltaY * scrollLineHeight;
-      }
+      let { deltaX, deltaY } = getScrollDeltas(event);
 
       // If the consequence of the wheel action would result in scrolling beyond
       // the scrollable canvas of the dropdown, call preventDefault() and clamp

--- a/addon/components/basic-dropdown/content.js
+++ b/addon/components/basic-dropdown/content.js
@@ -280,8 +280,8 @@ export default Component.extend({
           deltaY = 3;
         }
 
-        deltaX = event.deltaX * scrollLineHeight;
-        deltaY = event.deltaY * scrollLineHeight;
+        deltaX = deltaX * scrollLineHeight;
+        deltaY = deltaY * scrollLineHeight;
       }
 
       // If the consequence of the wheel action would result in scrolling beyond

--- a/addon/utils/scroll-helpers.js
+++ b/addon/utils/scroll-helpers.js
@@ -129,6 +129,10 @@ function calculateScrollDistribution(deltaX, deltaY, element, container, accumul
   const elementStyle = window.getComputedStyle(element);
 
   if (elementStyle.overflowX !== 'hidden') {
+    // The `deltaX` can be larger than the available scroll for the element, thus overshooting.
+    // The result of that is that it scrolls the element as far as possible. We don't need to
+    // calculate exactly because we reduce the amount of desired scroll for the
+    // parent elements by the correct amount below.
     scrollInformation.scrollLeft = element.scrollLeft + deltaX;
     if (deltaX > availableScroll.deltaXPositive) {
       deltaX = deltaX - availableScroll.deltaXPositive;

--- a/addon/utils/scroll-helpers.js
+++ b/addon/utils/scroll-helpers.js
@@ -1,3 +1,61 @@
+
+/**
+ * Mode that expresses the deltas in pixels.
+ *
+ * @property DOM_DELTA_PIXEL
+ */
+export const DOM_DELTA_PIXEL = 0;
+/**
+ * Mode that expresses the deltas in lines.
+ *
+ * This only happens in Firefox for Windows.
+ *
+ * Reference: https://stackoverflow.com/a/37474225
+ *
+ * @property DOM_DELTA_LINE
+ */
+export const DOM_DELTA_LINE = 1;
+/**
+ * Mode that expresses the deltas in pages.
+ *
+ * This only happens in Firefox for Windows with
+ * a custom OS setting activated.
+ *
+ * Reference: https://stackoverflow.com/a/37474225
+ */
+export const DOM_DELTA_PAGE = 2;
+
+/**
+ * Number of lines per page considered for
+ * DOM_DELTA_PAGE.
+ *
+ * @property LINES_PER_PAGE
+ */
+export const LINES_PER_PAGE = 3;
+
+
+/**
+ * Returns the deltas calculated in pixels.
+ *
+ * @param {Number} event.deltaX horizontal delta
+ * @param {Number} event.deltaY vertical delta
+ * @param {DeltaMode} event.deltaMode delta mode tells which unit is being used.
+ * @return {Object} Object with deltaX and deltaY properties
+ */
+export function getScrollDeltas({ deltaX = 0, deltaY = 0, deltaMode = DOM_DELTA_PIXEL }) {
+  if (deltaMode !== DOM_DELTA_PIXEL) {
+    if (deltaMode === DOM_DELTA_PAGE) {
+      deltaX *= LINES_PER_PAGE;
+      deltaY *= LINES_PER_PAGE;
+    }
+    const scrollLineHeight = getScrollLineHeight();
+    deltaX *= scrollLineHeight;
+    deltaY *= scrollLineHeight;
+  }
+
+  return { deltaX, deltaY };
+}
+
 let scrollLineHeight = null;
 export function getScrollLineHeight() {
   if (!scrollLineHeight) {

--- a/addon/utils/scroll-helpers.js
+++ b/addon/utils/scroll-helpers.js
@@ -126,23 +126,28 @@ function calculateScrollDistribution(deltaX, deltaY, element, container, accumul
     deltaYPositive: scrollTopMax - element.scrollTop
   };
 
-  scrollInformation.scrollLeft = element.scrollLeft + deltaX;
-  scrollInformation.scrollTop = element.scrollTop + deltaY;
+  const elementStyle = window.getComputedStyle(element);
 
-  if (deltaX > availableScroll.deltaXPositive) {
-    deltaX = deltaX - availableScroll.deltaXPositive;
-  } else if (deltaX < availableScroll.deltaXNegative) {
-    deltaX = deltaX - availableScroll.deltaXNegative;
-  } else {
-    deltaX = 0;
+  if (elementStyle.overflowX !== 'hidden') {
+    scrollInformation.scrollLeft = element.scrollLeft + deltaX;
+    if (deltaX > availableScroll.deltaXPositive) {
+      deltaX = deltaX - availableScroll.deltaXPositive;
+    } else if (deltaX < availableScroll.deltaXNegative) {
+      deltaX = deltaX - availableScroll.deltaXNegative;
+    } else {
+      deltaX = 0;
+    }
   }
 
-  if (deltaY > availableScroll.deltaYPositive) {
-    deltaY = deltaY - availableScroll.deltaYPositive;
-  } else if (deltaY < availableScroll.deltaYNegative) {
-    deltaY = deltaY - availableScroll.deltaYNegative;
-  } else {
-    deltaY = 0;
+  if (elementStyle.overflowY !== 'hidden') {
+    scrollInformation.scrollTop = element.scrollTop + deltaY;
+    if (deltaY > availableScroll.deltaYPositive) {
+      deltaY = deltaY - availableScroll.deltaYPositive;
+    } else if (deltaY < availableScroll.deltaYNegative) {
+      deltaY = deltaY - availableScroll.deltaYNegative;
+    } else {
+      deltaY = 0;
+    }
   }
 
   if (element !== container && (deltaX || deltaY)) {

--- a/tests/unit/utils/scroll-helpers-test.js
+++ b/tests/unit/utils/scroll-helpers-test.js
@@ -1,4 +1,13 @@
-import { getScrollLineHeight, getAvailableScroll, distributeScroll } from 'ember-basic-dropdown/utils/scroll-helpers';
+import {
+  distributeScroll,
+  getAvailableScroll,
+  getScrollDeltas,
+  getScrollLineHeight,
+  DOM_DELTA_LINE,
+  DOM_DELTA_PAGE,
+  DOM_DELTA_PIXEL,
+  LINES_PER_PAGE
+} from 'ember-basic-dropdown/utils/scroll-helpers';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | scroll helpers');
@@ -67,4 +76,43 @@ test('distributeScroll', function(assert) {
   distributeScroll(0, 40, grandchild, container);
   assert.strictEqual(container.scrollTop, 10);
   assert.strictEqual(child.scrollTop, 40);
+});
+
+test('getScrollDeltas DOM_DELTA_PIXEL', function(assert) {
+  const originalDeltaX = 25;
+  const originalDeltaY = 15;
+  const { deltaX, deltaY } = getScrollDeltas({
+    deltaX: originalDeltaX,
+    deltaY: originalDeltaY,
+    deltaMode: DOM_DELTA_PIXEL
+  });
+  assert.equal(deltaX, originalDeltaX);
+  assert.equal(deltaY, originalDeltaY);
+});
+
+test('getScrollDeltas DOM_DELTA_LINE', function(assert) {
+  const scrollLineHeight = getScrollLineHeight();
+  const originalDeltaX = 25;
+  const originalDeltaY = 15;
+  const { deltaX, deltaY } = getScrollDeltas({
+    deltaX: originalDeltaX,
+    deltaY: originalDeltaY,
+    deltaMode: DOM_DELTA_LINE
+  });
+  assert.equal(deltaX, originalDeltaX * scrollLineHeight);
+  assert.equal(deltaY, originalDeltaY * scrollLineHeight);
+});
+
+test('getScrollDeltas DOM_DELTA_PAGE', function(assert) {
+  const scrollLineHeight = getScrollLineHeight();
+  const originalDeltaX = 25;
+  const originalDeltaY = 15;
+  const { deltaX, deltaY } = getScrollDeltas({
+    deltaX: originalDeltaX,
+    deltaY: originalDeltaY,
+    deltaMode: DOM_DELTA_PAGE
+  });
+  assert.equal(deltaX, originalDeltaX * scrollLineHeight * LINES_PER_PAGE);
+  assert.equal(deltaY, originalDeltaY * scrollLineHeight * LINES_PER_PAGE);
+
 });


### PR DESCRIPTION
This improves the code that code in several ways.

* [Fix deltaX and deltaY calculation](https://github.com/cibernox/ember-basic-dropdown/commit/090d252bc3afffdf00291a44c4fd645898914e45) fixes a bug in part of the code (and later another one is fixed while refactoring).
* [Extract standardizing deltas to scroll helpers](https://github.com/cibernox/ember-basic-dropdown/commit/80322ee13b07fa9222b289f642f08e9adae9cdc7): there are several delta modes (some browsers might measure this in lines or even in pages), the code that standardises these deltas to be measured in pixel is extracted to scroll helpers and refactored, extracting and documenting some constants along the way.
* [Deinterlace reads and writes when scrolling](https://github.com/cibernox/ember-basic-dropdown/commit/3edda0a274bf4850529b20db67071e7032e00ea4): interlacing reads and writes can decrease perf. This code calculates first which modification need to be done and then apply them.
* [Avoid elements that have an overflow hidden in any direction](https://github.com/cibernox/ember-basic-dropdown/commit/86f147cd1301428f1a83660c65e547a0793dc295): if an element has an overflow hidden in any direction, that direction scroll is not applied. This only affects when both `preventScroll` and `renderInPlace` are true.