### PR TITLE
Allow user-defined uniqueId for dropdown component

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -44,6 +44,8 @@ export default Component.extend({
   width: null,
   height: null,
 
+  uniqueId: null,
+
   // Lifecycle hooks
   init() {
     if (this.get('renderInPlace') && this.get('tagName') === '') {
@@ -53,7 +55,7 @@ export default Component.extend({
     this.set('publicAPI', {});
 
     let publicAPI = this.updateState({
-      uniqueId: guidFor(this),
+      uniqueId: this.get('uniqueId') || guidFor(this),
       isOpen: this.get('initiallyOpened') || false,
       disabled: this.get('disabled') || false,
       actions: {

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -779,6 +779,26 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.ok(find('.body-parent'), 'can click in parent dropdown and still be open');
   });
 
+  test('Dropdown uniqueId can be specified or use the standard guidFor', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`
+      {{#basic-dropdown as |parent|}}
+        <span class="unique-id">{{parent.uniqueId}}</span>
+      {{/basic-dropdown}}
+    `);
+
+    assert.ok(find('.unique-id').innerText.match(/ember[\d]+/));
+
+    await render(hbs`
+      {{#basic-dropdown uniqueId='test123' as |parent|}}
+        <span class="unique-id">{{parent.uniqueId}}</span>
+      {{/basic-dropdown}}
+    `);
+
+    assert.equal(find('.unique-id').innerText, 'test123');
+  });
+
   // Misc bugfixes
   test('[BUGFIX] Dropdowns rendered in place do not register events twice', async function(assert) {
     assert.expect(2);


### PR DESCRIPTION
For situations where the `uniqueId` needs to be known by another element
or library but has not yet been defined, or is not defined in the same
context.