### PR TITLE
Add wrapper to overlay to prevent pointer bleed.

### DIFF
--- a/addon/templates/components/basic-dropdown/content.hbs
+++ b/addon/templates/components/basic-dropdown/content.hbs
@@ -2,7 +2,9 @@
   <div class="ember-basic-dropdown-content-wormhole-origin">
     {{#maybe-in-element destinationElement renderInPlace}}
       {{#if overlay}}
-        <div class="ember-basic-dropdown-overlay"></div>
+        <div class="ember-basic-dropdown-overlay-container">
+          <div class="ember-basic-dropdown-overlay"></div>
+        </div>
       {{/if}}
       {{#basic-dropdown/content-element
         tagName=_contentTagName

--- a/app/styles/ember-basic-dropdown.less
+++ b/app/styles/ember-basic-dropdown.less
@@ -19,6 +19,14 @@
 .ember-basic-dropdown-content--right { right: 0; }
 
 
+.ember-basic-dropdown-overlay-container {
+  cursor: pointer;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+}
+
 .ember-basic-dropdown-overlay {
   position: fixed;
   background: @ember-basic-dropdown-overlay-background;

--- a/app/styles/ember-basic-dropdown.scss
+++ b/app/styles/ember-basic-dropdown.scss
@@ -19,6 +19,14 @@ $ember-basic-dropdown-overlay-pointer-events: none !default;
 .ember-basic-dropdown-content--right { right: 0; }
 
 
+.ember-basic-dropdown-overlay-container {
+  cursor: pointer;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+}
+
 .ember-basic-dropdown-overlay {
   position: fixed;
   background: $ember-basic-dropdown-overlay-background;

--- a/vendor/ember-basic-dropdown.css
+++ b/vendor/ember-basic-dropdown.css
@@ -16,6 +16,13 @@
 .ember-basic-dropdown-content--right {
   right: 0; }
 
+.ember-basic-dropdown-overlay-container {
+  cursor: pointer;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  z-index: 10; }
+
 .ember-basic-dropdown-overlay {
   position: fixed;
   background: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
- Adds a wrapper element to the overlay to prevent the mouse events from going under the wormhole and triggering other element hover states etc.

Note: You can see the issue when you [go to the docs page](http://ember-basic-dropdown.com/docs/overlays), trigger the dropdown, and hover over a link that's in the background.