### PR TITLE
Use click from `ember-native-dom-helpers` if Ember Version < 3.0

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -6,11 +6,6 @@ import { click, settled } from '@ember/test-helpers';
 import { deprecate } from '@ember/debug';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
-// `click` from `@ember/test-helpers` doesn't play well on Ember version < 3.0
-if(!hasEmberVersion(3, 0)){
-  click = _nativeDomClick;
-}
-
 export function nativeTap(selector, options = {}) {
   let touchStartEvent = new window.Event('touchstart', { bubbles: true, cancelable: true, view: window });
   Object.keys(options).forEach(key => touchStartEvent[key] = options[key]);
@@ -30,7 +25,10 @@ export function clickTrigger(scope, options = {}) {
       selector = scope + ' ' + selector;
     }
   }
-  click(selector, options);
+
+  // `click` from `@ember/test-helpers` doesn't play well on Ember version < 3.0
+  hasEmberVersion(3, 0) ? click(selector, options) : _nativeDomClick(selector, options);
+
   return settled();
 }
 

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,9 +1,15 @@
 import { registerAsyncHelper } from '@ember/test';
 import { run } from '@ember/runloop';
 import { merge } from '@ember/polyfills';
+import { click as _nativeDomClick } from 'ember-native-dom-helpers';
 import { click, settled } from '@ember/test-helpers';
 import { deprecate } from '@ember/debug';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
+// `click` from `@ember/test-helpers` doesn't play well on Ember version < 3.0
+if(!hasEmberVersion(3, 0)){
+  click = _nativeDomClick;
+}
 
 export function nativeTap(selector, options = {}) {
   let touchStartEvent = new window.Event('touchstart', { bubbles: true, cancelable: true, view: window });

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-href-to": "~1.15.1",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-native-dom-event-dispatcher": "^0.6.4",
     "ember-resolver": "^4.5.0",
     "ember-source": "3.0.0",
     "ember-source-channel-url": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.12.0",
     "ember-cli-htmlbars": "^2.0.3",
+    "ember-native-dom-helpers": "^0.6.2",
     "ember-maybe-in-element": "^0.1.3"
   },
   "ember-addon": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,6 +2495,13 @@ ember-maybe-in-element@^0.1.3:
   dependencies:
     ember-cli-babel "^6.11.0"
 
+ember-native-dom-event-dispatcher@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-event-dispatcher/-/ember-native-dom-event-dispatcher-0.6.4.tgz#ba03d512a72d159a376b27593b497ba08fe14a8a"
+  dependencies:
+    ember-cli-babel "^6.11.0"
+    ember-cli-version-checker "^2.1.0"
+
 ember-native-dom-helpers@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"


### PR DESCRIPTION
Similar to this issue: https://github.com/cibernox/ember-power-select/issues/1085

If Ember version is < 3.0, the `click` from `@ember/test-helpers` throws `Must setup rendering context` error.

This PR lets projects using ember versions < 3.0 upgrade to the new Ember's latest testing APIs, based on RFCs [232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md) and [268](https://github.com/emberjs/rfcs/blob/master/text/0268-acceptance-testing-refactor.md).
