### PR TITLE
Remove extra space in documentation snippet

### DIFF
--- a/tests/dummy/app/templates/snippets/custom-position-1-js.js
+++ b/tests/dummy/app/templates/snippets/custom-position-1-js.js
@@ -6,7 +6,7 @@ export default Controller.extend({
     let { height: contentHeight } = content.getBoundingClientRect();
     let style = {
       left: left + width,
-      top: top +  window.pageYOffset + (height / 2) - (contentHeight / 2)
+      top: top + window.pageYOffset + (height / 2) - (contentHeight / 2)
     };
 
     return { style };


### PR DESCRIPTION
I got a lint error after copy-pasting this snippet in my code editor