### PR TITLE
Add dropdown-events-3-js and dropdown-events-4-js code snippet

### DIFF
--- a/tests/dummy/app/templates/snippets/dropdown-events-3-js.js
+++ b/tests/dummy/app/templates/snippets/dropdown-events-3-js.js
@@ -1,0 +1,12 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    preventUntilSelected() {
+      if (!this.get('selected')) {
+        alert('You have to choose!');
+        return false;
+      }
+    }
+  }
+});

--- a/tests/dummy/app/templates/snippets/dropdown-events-4-js.js
+++ b/tests/dummy/app/templates/snippets/dropdown-events-4-js.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  actions: {
+    openDropdown(dropdown) {
+      dropdown.actions.open();
+    }
+  }
+});


### PR DESCRIPTION
The controller code snippets for the `onClose` and `onFocus` events are blank. This PR adds the missing snippets, so that the controller code is displayed.