### PR TITLE
Check for FastBoot before calling document

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -272,7 +272,7 @@ export default Component.extend({
 
   _getDestinationId() {
     let config = getOwner(this).resolveRegistration('config:environment');
-    if (config.environment === 'test') {
+    if (config.environment === 'test' && (typeof FastBoot === 'undefined')) {
       if (DEBUG) {
         let id;
         if (requirejs.has('@ember/test-helpers/dom/get-root-element')) {


### PR DESCRIPTION
I'm working on a fastboot testing story and calling `document` from within the fastboot test made things fail.