### PR TITLE
Now that element modifiers can be forwarded we don't need to attach events ourselves

### DIFF
--- a/addon/components/basic-dropdown-content.js
+++ b/addon/components/basic-dropdown-content.js
@@ -139,22 +139,6 @@ export default class BasicDropdownContent extends Component {
       document.addEventListener('touchend', this.handleRootMouseDown, true);
     }
 
-    if (this.onFocusIn) {
-      dropdownElement.addEventListener('focusin', (e) => this.onFocusIn(this.dropdown, e));
-    }
-    if (this.onFocusOut) {
-      dropdownElement.addEventListener('focusout', (e) => this.onFocusOut(this.dropdown, e));
-    }
-    if (this.onMouseEnter) {
-      dropdownElement.addEventListener('mouseenter', (e) => this.onMouseEnter(this.dropdown, e));
-    }
-    if (this.onMouseLeave) {
-      dropdownElement.addEventListener('mouseleave', (e) => this.onMouseLeave(this.dropdown, e));
-    }
-    if (this.onKeyDown) {
-      dropdownElement.addEventListener('keydown', (e) => this.onKeyDown(this.dropdown, e));
-    }
-
     this.scrollableAncestors = this.getScrollableAncestors(triggerElement);
     this.addScrollHandling(dropdownElement);
     this.startObservingDomMutations(dropdownElement);

--- a/addon/components/basic-dropdown-trigger.js
+++ b/addon/components/basic-dropdown-trigger.js
@@ -136,31 +136,6 @@ export default class BasicDropdownTrigger extends Component {
   }
 
   @action
-  addOptionalHandlers(triggerEl) {
-    if (this.onMouseEnter) {
-      triggerEl.addEventListener('mouseenter', (e) => this.onMouseEnter(this.dropdown, e));
-    }
-    if (this.onMouseLeave) {
-      triggerEl.addEventListener('mouseleave', (e) => this.onMouseLeave(this.dropdown, e));
-    }
-    if (this.onFocus) {
-      triggerEl.addEventListener('focus', (e) => this.onFocus(this.dropdown, e));
-    }
-    if (this.onBlur) {
-      triggerEl.addEventListener('blur', (e) => this.onBlur(this.dropdown, e));
-    }
-    if (this.onFocusIn) {
-      triggerEl.addEventListener('focusin', (e) => this.onFocusIn(this.dropdown, e));
-    }
-    if (this.onFocusOut) {
-      triggerEl.addEventListener('focusout', (e) => this.onFocusOut(this.dropdown, e));
-    }
-    if (this.onKeyUp) {
-      triggerEl.addEventListener('keyup', (e) => this.onKeyUp(this.dropdown, e));
-    }
-  }
-
-  @action
   _mouseupHandler() {
     document.removeEventListener('mouseup', this._mouseupHandler, true);
     document.body.classList.remove('ember-basic-dropdown-text-select-disabled');

--- a/addon/templates/components/basic-dropdown-trigger.hbs
+++ b/addon/templates/components/basic-dropdown-trigger.hbs
@@ -8,7 +8,6 @@
     aria-expanded={{if @dropdown.isOpen "true"}}
     aria-disabled={{if @dropdown.disabled "true"}}
     {{did-insert (action this.addTouchHandlers)}}
-    {{did-insert this.addOptionalHandlers}}
     {{will-destroy this.removeGlobalHandlers}}
     {{on "mousedown" this.handleMouseDown}}
     {{on "click" this.handleClick}}

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -207,31 +207,6 @@
       <td><strong>[DEPRECATED]</strong>The selector of a DOM element where the dropdown will be rendered using ember-wormhole</td>
     </tr>
     <tr>
-      <td>onFocusIn</td>
-      <td>Function</td>
-      <td>Function invoked when the <code>focusin</code> even is fired withing the component</td>
-    </tr>
-    <tr>
-      <td>onFocusOut</td>
-      <td>Function</td>
-      <td>Function invoked when the <code>focusout</code> even is fired withing the component</td>
-    </tr>
-    <tr>
-      <td>onMouseEnter</td>
-      <td>Function</td>
-      <td>Function invoked when the <code>mouseenter</code> even is fired withing the component</td>
-    </tr>
-    <tr>
-      <td>onMouseLeave</td>
-      <td>Function</td>
-      <td>Function invoked when the <code>mouseleave</code> even is fired withing the component</td>
-    </tr>
-    <tr>
-      <td>onKeyDown</td>
-      <td>Function</td>
-      <td>Action that will be invoked when a <code>keydown</code> event is fired on the content</td>
-    </tr>
-    <tr>
       <td>animationEnabled</td>
       <td>boolean</td>
       <td>Flag to determine whether the content will allow CSS animations. Defaults to true</td>

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -143,34 +143,9 @@
       <td>Extra classes to be added to the trigger components</td>
     </tr>
     <tr>
-      <td>onBlur</td>
-      <td>Function</td>
-      <td>Action that will be invoked when a <code>blur</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
-      <td>onFocus</td>
-      <td>Function</td>
-      <td>Action that will be invoked when a <code>focus</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
-      <td>onFocusIn</td>
-      <td>Function</td>
-      <td>Action that will be invoked when a <code>focusin</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
-      <td>onFocusOut</td>
-      <td>Function</td>
-      <td>Action that will be invoked when a <code>focusout</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
       <td>onKeyDown</td>
       <td>Function</td>
       <td>Action that will be invoked when a <code>keydown</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
-      <td>onKeyUp</td>
-      <td>Function</td>
-      <td>Action that will be invoked when a <code>keyup</code> event is fired on the trigger</td>
     </tr>
     <tr>
       <td>onClick</td>
@@ -181,16 +156,6 @@
       <td>onMouseDown</td>
       <td>Function</td>
       <td>Action that will be invoked when an <code>mousedown</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
-      <td>onMouseEnter</td>
-      <td>Function</td>
-      <td>Action that will be invoked when an <code>mouseenter</code> event is fired on the trigger</td>
-    </tr>
-    <tr>
-      <td>onMouseLeave</td>
-      <td>Function</td>
-      <td>Action that will be invoked when an <code>mouseleave</code> event is fired on the trigger</td>
     </tr>
     <tr>
       <td>onTouchEnd</td>

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -790,7 +790,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
       <input type="text" id="outer-input">
       <BasicDropdown @renderInPlace={{true}} @onOpen={{onOpen}} as |dropdown|>
         <dropdown.Trigger>Open me</dropdown.Trigger>
-        <dropdown.Content @onFocusOut={{onFocusOut}}><input type="text" id="inner-input"></dropdown.Content>
+        <dropdown.Content {{on "focusout" onFocusOut}}><input type="text" id="inner-input"></dropdown.Content>
       </BasicDropdown>
     `);
     await click('.ember-basic-dropdown-trigger');

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
-import { render, click, triggerEvent, focus, blur, triggerKeyEvent } from '@ember/test-helpers';
+import { render, click, triggerEvent } from '@ember/test-helpers';
 
 module('Integration | Component | basic-dropdown-content', function(hooks) {
   setupRenderingTest(hooks);
@@ -268,7 +268,7 @@ module('Integration | Component | basic-dropdown-content', function(hooks) {
     };
     await render(hbs`
       <div id="destination-el"></div>
-      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" {{on "mouseenter (fn onMouseEnter dropdown}}>
+      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" {{on "mouseenter" (fn onMouseEnter dropdown)}}>
         Content
       </BasicDropdownContent>
     `);

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -257,44 +257,8 @@ module('Integration | Component | basic-dropdown-content', function(hooks) {
     await triggerEvent('#other-div', 'touchend');
   });
 
-  // // Focus
-  test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired inside the content', async function(assert) {
-    assert.expect(3);
-    this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
-    this.onFocusIn = (api, e) => {
-      assert.ok(true, 'The action is invoked');
-      assert.equal(api, this.dropdown, 'The first argument is the API');
-      assert.ok(e instanceof window.Event, 'the second argument is an event');
-    };
-    await render(hbs`
-      <div id="destination-el"></div>
-      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" @onFocusIn={{onFocusIn}}>
-        <input type="text" id="test-input-focusin" />
-      </BasicDropdownContent>
-    `);
-    await focus('#test-input-focusin');
-  });
-
-  test('If it receives an `onFocusOut` action, it is invoked if a focusout event is fired inside the content', async function(assert) {
-    assert.expect(3);
-    this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
-    this.onFocusOut = (api, e) => {
-      assert.ok(true, 'The action is invoked');
-      assert.equal(api, this.dropdown, 'The first argument is the API');
-      assert.ok(e instanceof window.Event, 'the second argument is an event');
-    };
-    await render(hbs`
-      <div id="destination-el"></div>
-      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" @onFocusOut={{onFocusOut}}>
-        <input type="text" id="test-input-focusin" />
-      </BasicDropdownContent>
-    `);
-    await focus('#test-input-focusin');
-    await blur('#test-input-focusin');
-  });
-
-  // Mouseenter/leave
-  test('If it receives an `onMouseEnter` action, it is invoked if a mouseenter event is fired on the content', async function(assert) {
+  // Arbitrary events
+  test('The user can attach arbitrary events to the content', async function(assert) {
     assert.expect(3);
     this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
     this.onMouseEnter = (api, e) => {
@@ -304,47 +268,11 @@ module('Integration | Component | basic-dropdown-content', function(hooks) {
     };
     await render(hbs`
       <div id="destination-el"></div>
-      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" @onMouseEnter={{onMouseEnter}}>
+      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" {{on "mouseenter (fn onMouseEnter dropdown}}>
         Content
       </BasicDropdownContent>
     `);
     await triggerEvent('.ember-basic-dropdown-content', 'mouseenter');
-  });
-
-  test('If it receives an `onMouseLeave` action, it is invoked if a mouseleave event is fired on the content', async function(assert) {
-    assert.expect(3);
-    this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
-    this.onMouseLeave = (api, e) => {
-      assert.ok(true, 'The action is invoked');
-      assert.equal(api, this.dropdown, 'The first argument is the API');
-      assert.ok(e instanceof window.Event, 'the second argument is an event');
-    };
-    await render(hbs`
-      <div id="destination-el"></div>
-      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" @onMouseLeave={{onMouseLeave}}>
-        Content
-      </BasicDropdownContent>
-    `);
-    await triggerEvent('.ember-basic-dropdown-content', 'mouseleave');
-  });
-
-  // Keydown
-  test('If it receives an `onKeyDown` action, it is invoked if a keydown event is fired on the content', async function (assert) {
-    assert.expect(3);
-    this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
-    this.onKeyDown = (api, e) => {
-      assert.equal(api, this.dropdown, 'receives the dropdown as 1st argument');
-      assert.ok(e instanceof window.Event, 'It receives the event as second argument');
-      assert.equal(e.keyCode, 70, 'the event is the keydown event');
-    };
-    await render(hbs`
-      <div id="destination-el"></div>
-      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" @onKeyDown={{onKeyDown}}>
-        <input id="inner-input">
-      </BasicDropdownContent>
-    `);
-    await focus('#inner-input');
-    await triggerKeyEvent('#inner-input', 'keydown', 70);
   });
 
   // Repositining

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { render, triggerEvent, triggerKeyEvent, focus, tap, click } from '@ember/test-helpers';
+import { render, triggerEvent, triggerKeyEvent, tap, click } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import { set } from '@ember/object'
 

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -144,7 +144,8 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
   });
 
   // Custom actions
-  test('If it receives an `@onMouseEnter` action, it will be invoked when a mouseenter event is received', async function(assert) {
+  // test('the user can bind arbitrary events to the trigger `@onMouseEnter` action, it will be invoked when a mouseenter event is received', async function(assert) {
+  test('the user can bind arbitrary events to the trigger', async function(assert) {
     assert.expect(2);
     this.dropdown = { uniqueId: 123 };
     this.onMouseEnter = (dropdown, e) => {
@@ -152,49 +153,9 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
       assert.ok(e instanceof window.Event, 'It receives the event as second argument');
     };
     await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onMouseEnter={{onMouseEnter}}>Click me</BasicDropdownTrigger>
+      <BasicDropdownTrigger @dropdown={{dropdown}} {{on "mouseenter" (fn onMouseEnter dropdown)}}>Click me</BasicDropdownTrigger>
     `);
     await triggerEvent('.ember-basic-dropdown-trigger', 'mouseenter');
-  });
-
-  test('If it receives an `onMouseLeave` action, it will be invoked when a mouseleave event is received', async function(assert) {
-    assert.expect(2);
-    this.onMouseLeave = (dropdown, e) => {
-      assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
-      assert.ok(e instanceof window.Event, 'It receives the event as second argument');
-    };
-    this.dropdown = { uniqueId: 123 };
-    await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onMouseLeave={{onMouseLeave}}>Click me</BasicDropdownTrigger>
-    `);
-    await triggerEvent('.ember-basic-dropdown-trigger', 'mouseleave');
-  });
-
-  test('If it receives an `onFocus` action, it will be invoked when it get focused', async function(assert) {
-    assert.expect(2);
-    this.onFocus = (dropdown, e) => {
-      assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
-      assert.ok(e instanceof window.Event, 'It receives the event as second argument');
-    };
-    this.dropdown = { uniqueId: 123 };
-    await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onFocus={{onFocus}}>Click me</BasicDropdownTrigger>
-    `);
-    await focus('.ember-basic-dropdown-trigger');
-  });
-
-  test('If it receives an `onBlur` action, it will be invoked when it get blurred', async function(assert) {
-    assert.expect(2);
-    this.onBlur = (dropdown, e) => {
-      assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
-      assert.ok(e instanceof window.Event, 'It receives the event as second argument');
-    };
-    this.dropdown = { uniqueId: 123 };
-    await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onBlur={{onBlur}}>Click me</BasicDropdownTrigger>
-    `);
-    await focus('.ember-basic-dropdown-trigger');
-    await blur('.ember-basic-dropdown-trigger');
   });
 
   test('If it receives an `onKeyDown` action, it will be invoked when a key is pressed while the component is focused', async function(assert) {
@@ -209,20 +170,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
       <BasicDropdownTrigger @dropdown={{dropdown}} @onKeyDown={{onKeyDown}}>Click me</BasicDropdownTrigger>
     `);
     triggerKeyEvent('.ember-basic-dropdown-trigger', 'keydown', 70);
-  });
-
-  test('If it receives an `onKeyUp` action, it will be invoked when a key is pressed while the component is focused', async function(assert) {
-    assert.expect(3);
-    this.onKeyUp = (dropdown, e) => {
-      assert.equal(dropdown, this.dropdown, 'receives the dropdown as 1st argument');
-      assert.ok(e instanceof window.Event, 'It receives the event as second argument');
-      assert.equal(e.keyCode, 70, 'the event is the keydown event');
-    };
-    this.dropdown = { uniqueId: 123 };
-    await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onKeyUp={{onKeyUp}}>Click me</BasicDropdownTrigger>
-    `);
-    triggerKeyEvent('.ember-basic-dropdown-trigger', 'keyup', 70);
   });
 
   // Default behaviour
@@ -474,39 +421,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
     await triggerKeyEvent('.ember-basic-dropdown-trigger', 'keydown', 13);
     await triggerKeyEvent('.ember-basic-dropdown-trigger', 'keydown', 32);
     await triggerKeyEvent('.ember-basic-dropdown-trigger', 'keydown', 27);
-  });
-
-  // Focus
-  test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired on the trigger', async function(assert) {
-    assert.expect(3);
-    this.dropdown = { uniqueId: 123, isOpen: true, actions: { reposition() { } } };
-    this.onFocusIn = (api, e) => {
-      assert.ok(true, 'The action is invoked');
-      assert.equal(api, this.dropdown, 'The first argument is the API');
-      assert.ok(e instanceof window.Event, 'the second argument is an event');
-    };
-    await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onFocusIn={{onFocusIn}}>
-        <input type="text" id="test-input-focusin" />
-      </BasicDropdownTrigger>
-    `);
-    await focus('#test-input-focusin');
-  });
-
-  test('If it receives an `onFocusIn` action, it is invoked if a focusin event is fired on the trigger', async function(assert) {
-    assert.expect(3);
-    this.dropdown = { uniqueId: 123, isOpen: true, actions: { reposition() { } } };
-    this.onFocusOut = (api, e) => {
-      assert.ok(true, 'The action is invoked');
-      assert.equal(api, this.dropdown, 'The first argument is the API');
-      assert.ok(e instanceof window.Event, 'the second argument is an event');
-    };
-    await render(hbs`
-      <BasicDropdownTrigger @dropdown={{dropdown}} @onFocusOut={{onFocusOut}}>
-        <input type="text" id="test-input-focusout" />
-      </BasicDropdownTrigger>
-    `);
-    await focus('#test-input-focusout');
   });
 
   // Decorating and overriding default event handlers

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -144,7 +144,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
   });
 
   // Custom actions
-  // test('the user can bind arbitrary events to the trigger `@onMouseEnter` action, it will be invoked when a mouseenter event is received', async function(assert) {
   test('the user can bind arbitrary events to the trigger', async function(assert) {
     assert.expect(2);
     this.dropdown = { uniqueId: 123 };


### PR DESCRIPTION
There's a bit more boiler plate for users, but greatly simplifies that users have to know.