### PR TITLE
Issue #420 - Splitting onOpen and onClose to before and after actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.6
+- [DEPRECATION] Deprecate onOpen and onClose hooks. Suggest to use onBeforeOpen and onBeforeClose
+- [ENHANCEMENT] Add onAfterOpen and onAfterClose hooks that are called after changes in the dropdown state
+
 # 2.0.5
 - [CHORE] Update npm packages to tests pass in beta and canary
 - [BUGFIX] Ensure Ember doesn't complain about not using `set` to update values.

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -10,6 +10,7 @@ import templateLayout from '../templates/components/basic-dropdown';
 import calculatePosition from '../utils/calculate-position';
 import { assign } from '@ember/polyfills';
 import requirejs from 'require';
+import { deprecate } from '@ember/application/deprecations';
 
 const ignoredStyleAttrs = [
   'top',
@@ -89,10 +90,23 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
     if (this.publicAPI.disabled || this.publicAPI.isOpen) {
       return;
     }
-    if (this.onOpen && this.onOpen(this.publicAPI, e) === false) {
+    if (this.onOpen) {
+      deprecate("onOpen is deprecated and will be removed in the future. Please use onBeforeOpen instead", false, {
+        id: 'ember-basic-dropdown.onOpen',
+        until: '3.0.0',
+        url: 'https://ember-basic-dropdown.com/docs/dropdown-events',
+      });
+      if (this.onOpen(this.publicAPI, e) === false) {
+        return;
+      }
+    }
+    if (this.onBeforeOpen && this.onBeforeOpen(this.publicAPI, e) === false) {
       return;
     }
     this.updateState({ isOpen: true });
+    if (this.onAfterOpen) {
+      this.onAfterOpen(this.publicAPI, e);
+    }
   }
 
   close(e, skipFocus) {
@@ -102,7 +116,17 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
     if (this.publicAPI.disabled || !this.publicAPI.isOpen) {
       return;
     }
-    if (this.onClose && this.onClose(this.publicAPI, e) === false) {
+    if (this.onClose) {
+      deprecate("onClose is deprecated and will be removed in the future. Please use onBeforeClose instead", false, {
+        id: 'ember-basic-dropdown.onClose',
+        until: '3.0.0',
+        url: 'https://ember-basic-dropdown.com/docs/dropdown-events',
+      });
+      if (this.onClose(this.publicAPI, e) === false) {
+        return;
+      }
+    }
+    if (this.onBeforeClose && this.onBeforeClose(this.publicAPI, e) === false) {
       return;
     }
     if (this.isDestroyed) {
@@ -111,6 +135,10 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
     this.setProperties({ hPosition: null, vPosition: null, top: null, left: null, right: null, width: null, height: null });
     this.previousVerticalPosition = this.previousHorizontalPosition = null;
     this.updateState({ isOpen: false });
+    // NOTE: onAfterClose isn't going to be called if the dropdown was destroyed
+    if (this.onAfterClose) {
+      this.onAfterClose(this.publicAPI, e);
+    }
     if (skipFocus) {
       return;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-basic-dropdown",
-  "version": "2.0.5",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "2.0.6",
+  "description": "The basic dropdown that your ember needs",
   "homepage": "http://ember-basic-dropdown.com",
   "scripts": {
     "build": "ember build",

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -89,14 +89,34 @@
       <td>An action that will be invoked with the new public API of the component every time there is a change in the state of the component.</td>
     </tr>
     <tr>
-      <td>onOpen</td>
+      <td>onBeforeOpen</td>
       <td><code>Function</code></td>
       <td>Action that will be called when the component is about to open. Returning <code>false</code> from this function will prevent the component from being opened.</td>
     </tr>
     <tr>
-      <td>onClose    </td>
+      <td>onAfterOpen</td>
       <td><code>Function</code></td>
-      <td>Action that will be called when the component is about to close. Returning <code>false</code> from this function will prevent the component from being closed.</td>
+      <td>Action that will be called when the component has finished opening</td>
+    </tr>
+    <tr>
+      <td>onBeforeClose</td>
+      <td><code>Function</code></td>
+      <td>Action that will be called when the component is about to close. Returning <code>false</code> from this function will prevent the component from being opened.</td>
+    </tr>
+    <tr>
+      <td>onAfterClose</td>
+      <td><code>Function</code></td>
+      <td>Action that will be called when the component has finished closing <b>only if</b> the dropdown hasn't been destroyed.</td>
+    </tr>
+    <tr>
+      <td>onOpen</td>
+      <td><code>Function</code></td>
+      <td><strong>[DEPRECATED]</strong> Action that will be called when the component is about to open. Returning <code>false</code> from this function will prevent the component from being opened.</td>
+    </tr>
+    <tr>
+      <td>onClose</td>
+      <td><code>Function</code></td>
+      <td><strong>[DEPRECATED]</strong> Action that will be called when the component is about to close. Returning <code>false</code> from this function will prevent the component from being closed.</td>
     </tr>
   </tbody>
 </table>

--- a/tests/dummy/app/templates/public-pages/docs/dropdown-events.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/dropdown-events.hbs
@@ -9,7 +9,7 @@
   This has no mystery.
 </p>
 
-<h3><code>onOpen(dropdown, event?)</code></h3>
+<h3><code>onBeforeOpen(dropdown, event?)</code></h3>
 
 <p>
   Pretty self-explanatory. The <code>dropdown</code> argument in the signature
@@ -46,7 +46,7 @@
 
 <p><em><small>For the record, I don't think this is good UX</small></em></p>
 
-<h3><code>onClose(dropdown, event?)</code></h3>
+<h3><code>onBeforeClose(dropdown, event?)</code></h3>
 
 <p>
   Symmetrically, you can perform on action when the dropdown is closed. For example, save
@@ -64,6 +64,19 @@
 {{/code-example}}
 
 <p>Cruel, isn't it?</p>
+
+<h3><code>onAfterOpen(dropdown, event?)</code></h3>
+
+<p>
+  In addition to the <i>before</i> hooks mentioned above, there are accompanying hooks that get called immediately after state has been changed in the dropdown. The <code>dropdown</code> argument is the updated public API of the component that reflects these changes in state.
+</p>
+
+<h3><code>onAfterClose(dropdown, event?)</code></h3>
+
+<p>
+  There is something you should know about this hook: If the dropdown has been destroyed,
+  this will not get called.
+</p>
 
 <p>
   Those were the events fired by the top-level component, now let's go deep on the

--- a/tests/dummy/app/templates/snippets/custom-position-2.hbs
+++ b/tests/dummy/app/templates/snippets/custom-position-2.hbs
@@ -1,4 +1,4 @@
-<BasicDropdown @calculatePosition={{calculatePosition}} @onOpen={{perform addNames}} as |dd|>
+<BasicDropdown @calculatePosition={{calculatePosition}} @onBeforeOpen={{perform addNames}} as |dd|>
   <dd.Trigger class="trigger-bootstrap-feel">Click me</dd.Trigger>
 
   <dd.Content class="content-bootstrap-feel arrow-left-content">

--- a/tests/dummy/app/templates/snippets/dropdown-events-1.hbs
+++ b/tests/dummy/app/templates/snippets/dropdown-events-1.hbs
@@ -1,4 +1,4 @@
-<BasicDropdown @onOpen={{perform this.loadUsers}} as |dd|>
+<BasicDropdown @onBeforeOpen={{perform this.loadUsers}} as |dd|>
   <dd.Trigger class="trigger-bootstrap-feel">Click me</dd.Trigger>
 
   <dd.Content class="content-bootstrap-feel width-300">

--- a/tests/dummy/app/templates/snippets/dropdown-events-2.hbs
+++ b/tests/dummy/app/templates/snippets/dropdown-events-2.hbs
@@ -1,4 +1,4 @@
-<BasicDropdown @onOpen={{this.waitForUsers}} as |dd|>
+<BasicDropdown @onBeforeOpen={{this.waitForUsers}} as |dd|>
   <dd.Trigger class="trigger-bootstrap-feel">
     {{#if this.loadUsersAndOpen.isRunning}}
       Loading...

--- a/tests/dummy/app/templates/snippets/dropdown-events-3.hbs
+++ b/tests/dummy/app/templates/snippets/dropdown-events-3.hbs
@@ -1,4 +1,4 @@
-<BasicDropdown @onClose={{this.preventUntilSelected}} as |dd|>
+<BasicDropdown @onBeforeClose={{this.preventUntilSelected}} as |dd|>
   <dd.Trigger class="trigger-bootstrap-feel">Click me</dd.Trigger>
 
   <dd.Content class="content-bootstrap-feel width-300">

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -93,17 +93,17 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.dom('#dropdown-is-opened').doesNotExist('The dropdown is still closed');
   });
 
-  test('It can receive an onOpen action that is fired just before the component opens', async function(assert) {
+  test('It can receive an onBeforeOpen action that is fired just before the component opens', async function(assert) {
     assert.expect(4);
 
     this.willOpen = function(dropdown, e) {
       assert.equal(dropdown.isOpen, false, 'The received dropdown has a `isOpen` property that is still false');
       assert.ok(Object.prototype.hasOwnProperty.call(dropdown, 'actions'), 'The received dropdown has a `actions` property');
       assert.ok(!!e, 'Receives an argument as second argument');
-      assert.ok(true, 'onOpen action was invoked');
+      assert.ok(true, 'onBeforeOpen action was invoked');
     };
     await render(hbs`
-      <BasicDropdown @onOpen={{willOpen}} as |dropdown|>
+      <BasicDropdown @onBeforeOpen={{willOpen}} as |dropdown|>
         <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.open}}></button>
         {{#if dropdown.isOpen}}
           <div id="dropdown-is-opened"></div>
@@ -114,7 +114,28 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     await click('.ember-basic-dropdown-trigger');
   });
 
-  test('returning false from the `onOpen` action prevents the dropdown from opening', async function(assert) {
+  test('It can receive an onAfterOpen action that is fired just after the component opens', async function(assert) {
+    assert.expect(4);
+
+    this.willOpen = function(dropdown, e) {
+      assert.equal(dropdown.isOpen, true, 'The received dropdown has a `isOpen` property that now true');
+      assert.ok(Object.prototype.hasOwnProperty.call(dropdown, 'actions'), 'The received dropdown has a `actions` property');
+      assert.ok(!!e, 'Receives an argument as second argument');
+      assert.ok(true, 'onAfterOpen action was invoked');
+    };
+    await render(hbs`
+      <BasicDropdown @onAfterOpen={{willOpen}} as |dropdown|>
+        <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.open}}></button>
+        {{#if dropdown.isOpen}}
+          <div id="dropdown-is-opened"></div>
+        {{/if}}
+      </BasicDropdown>
+    `);
+
+    await click('.ember-basic-dropdown-trigger');
+  });
+
+  test('returning false from the `onBeforeOpen` action prevents the dropdown from opening', async function(assert) {
     assert.expect(2);
 
     this.willOpen = function() {
@@ -122,7 +143,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
       return false;
     };
     await render(hbs`
-      <BasicDropdown @onOpen={{willOpen}} as |dropdown|>
+      <BasicDropdown @onBeforeOpen={{willOpen}} as |dropdown|>
         <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.open}}></button>
         {{#if dropdown.isOpen}}
           <div id="dropdown-is-opened"></div>
@@ -134,17 +155,17 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.dom('#dropdown-is-opened').doesNotExist('The dropdown is still closed');
   });
 
-  test('It can receive an onClose action that is fired when the component closes', async function(assert) {
+  test('It can receive an onBeforeClose action that is fired just before the component closes', async function(assert) {
     assert.expect(7);
 
     this.willClose = function(dropdown, e) {
       assert.equal(dropdown.isOpen, true, 'The received dropdown has a `isOpen` property and its value is `true`');
       assert.ok(Object.prototype.hasOwnProperty.call(dropdown, 'actions'), 'The received dropdown has a `actions` property');
       assert.ok(!!e, 'Receives an argument as second argument');
-      assert.ok(true, 'onClose action was invoked');
+      assert.ok(true, 'onBeforeClose action was invoked');
     };
     await render(hbs`
-      <BasicDropdown @onClose={{willClose}} as |dropdown|>
+      <BasicDropdown @onBeforeClose={{willClose}} as |dropdown|>
         <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.toggle}}></button>
         {{#if dropdown.isOpen}}
           <div id="dropdown-is-opened"></div>
@@ -156,10 +177,35 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     await click('.ember-basic-dropdown-trigger');
     assert.dom('#dropdown-is-opened').exists('The dropdown is opened');
     await click('.ember-basic-dropdown-trigger');
-    assert.dom('#dropdown-is-opened').doesNotExist('The dropdown is now opened');
+    assert.dom('#dropdown-is-opened').doesNotExist('The dropdown is now closed');
   });
 
-  test('returning false from the `onClose` action prevents the dropdown from closing', async function(assert) {
+  test('It can receive an onAfterClose action that is fired just after the component closes', async function(assert) {
+    assert.expect(7);
+
+    this.willClose = function(dropdown, e) {
+      assert.equal(dropdown.isOpen, false, 'The received dropdown has a `isOpen` property and its value is `false`');
+      assert.ok(Object.prototype.hasOwnProperty.call(dropdown, 'actions'), 'The received dropdown has a `actions` property');
+      assert.ok(!!e, 'Receives an argument as second argument');
+      assert.ok(true, 'onAfterClose action was invoked');
+    };
+    await render(hbs`
+      <BasicDropdown @onAfterClose={{willClose}} as |dropdown|>
+        <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.toggle}}></button>
+        {{#if dropdown.isOpen}}
+          <div id="dropdown-is-opened"></div>
+        {{/if}}
+      </BasicDropdown>
+    `);
+
+    assert.dom('#dropdown-is-opened').doesNotExist('The dropdown is closed');
+    await click('.ember-basic-dropdown-trigger');
+    assert.dom('#dropdown-is-opened').exists('The dropdown is opened');
+    await click('.ember-basic-dropdown-trigger');
+    assert.dom('#dropdown-is-opened').doesNotExist('The dropdown is now closed');
+  });
+
+  test('returning false from the `onBeforeClose` action prevents the dropdown from closing', async function(assert) {
     assert.expect(4);
 
     this.willClose = function() {
@@ -167,7 +213,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
       return false;
     };
     await render(hbs`
-      <BasicDropdown @onClose={{willClose}} as |dropdown|>
+      <BasicDropdown @onBeforeClose={{willClose}} as |dropdown|>
         <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.toggle}}></button>
         {{#if dropdown.isOpen}}
           <div id="dropdown-is-opened"></div>
@@ -196,7 +242,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.dom('#dropdown-is-opened').exists('The dropdown is opened');
   });
 
-  test('Calling the `open` method while the dropdown is already opened does not call `onOpen` action', async function(assert) {
+  test('Calling the `open` method while the dropdown is already opened does not call `onBeforeOpen` action', async function(assert) {
     assert.expect(1);
     let onOpenCalls = 0;
     this.onOpen = () => {
@@ -204,7 +250,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     };
 
     await render(hbs`
-      <BasicDropdown @onOpen={{onOpen}} as |dropdown|>
+      <BasicDropdown @onBeforeOpen={{onOpen}} as |dropdown|>
         <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.open}}></button>
         {{#if dropdown.isOpen}}
           <div id="dropdown-is-opened"></div>
@@ -217,7 +263,28 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.equal(onOpenCalls, 1, 'onOpen has been called only once');
   });
 
-  test('Calling the `close` method while the dropdown is already opened does not call `onOpen` action', async function(assert) {
+  test('Calling the `open` method while the dropdown is already opened does not call `onAfterOpen` action', async function(assert) {
+    assert.expect(1);
+    let onOpenCalls = 0;
+    this.onOpen = () => {
+      onOpenCalls++;
+    };
+
+    await render(hbs`
+      <BasicDropdown @onAfterOpen={{onOpen}} as |dropdown|>
+        <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.open}}></button>
+        {{#if dropdown.isOpen}}
+          <div id="dropdown-is-opened"></div>
+        {{/if}}
+      </BasicDropdown>
+    `);
+    await click('.ember-basic-dropdown-trigger');
+    await click('.ember-basic-dropdown-trigger');
+    await click('.ember-basic-dropdown-trigger');
+    assert.equal(onOpenCalls, 1, 'onOpen has been called only once');
+  });
+
+  test('Calling the `close` method while the dropdown is already closed does not call `onBeforeClose` action', async function(assert) {
     assert.expect(1);
     let onCloseCalls = 0;
     this.onFocus = (dropdown) => {
@@ -228,7 +295,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     };
 
     await render(hbs`
-      <BasicDropdown @onClose={{onClose}} as |dropdown|>
+      <BasicDropdown @onBeforeClose={{onClose}} as |dropdown|>
         <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.close}}></button>
         {{#if dropdown.isOpen}}
           <div id="dropdown-is-opened"></div>
@@ -238,7 +305,31 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     await click('.ember-basic-dropdown-trigger');
     await click('.ember-basic-dropdown-trigger');
     await click('.ember-basic-dropdown-trigger');
-    assert.equal(onCloseCalls, 0, 'onClose was never called');
+    assert.equal(onCloseCalls, 0, 'onBeforeClose was never called');
+  });
+
+  test('Calling the `close` method while the dropdown is already closed does not call `onAfterClose` action', async function(assert) {
+    assert.expect(1);
+    let onCloseCalls = 0;
+    this.onFocus = (dropdown) => {
+      dropdown.actions.close();
+    };
+    this.onClose = () => {
+      onCloseCalls++;
+    };
+
+    await render(hbs`
+      <BasicDropdown @onAfterClose={{onClose}} as |dropdown|>
+        <button class="ember-basic-dropdown-trigger" onclick={{dropdown.actions.close}}></button>
+        {{#if dropdown.isOpen}}
+          <div id="dropdown-is-opened"></div>
+        {{/if}}
+      </BasicDropdown>
+    `);
+    await click('.ember-basic-dropdown-trigger');
+    await click('.ember-basic-dropdown-trigger');
+    await click('.ember-basic-dropdown-trigger');
+    assert.equal(onCloseCalls, 0, 'onAfterClose was never called');
   });
 
   test('It adds the proper class to trigger and content when it receives `horizontalPosition="right"`', async function(assert) {
@@ -726,7 +817,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.equal(apis[3].disabled, true, 'and it became disabled');
   });
 
-  test('removing the dropdown in response to onClose does not error', async function(assert) {
+  test('removing the dropdown in response to onBeforeClose does not error', async function(assert) {
     assert.expect(2);
 
     this.isOpen = true;
@@ -737,7 +828,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
 
     await render(hbs`
       {{#if isOpen}}
-        <BasicDropdown @onClose={{onClose}} as |dropdown|>
+        <BasicDropdown @onBeforeClose={{onClose}} as |dropdown|>
           <dropdown.Trigger>Open me</dropdown.Trigger>
           <dropdown.Content><h3>Content of the dropdown</h3></dropdown.Content>
         </BasicDropdown>
@@ -824,7 +915,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     }
     await render(hbs`
       <input type="text" id="outer-input">
-      <BasicDropdown @renderInPlace={{true}} @onOpen={{onOpen}} as |dropdown|>
+      <BasicDropdown @renderInPlace={{true}} @onBeforeOpen={{onOpen}} as |dropdown|>
         <dropdown.Trigger>Open me</dropdown.Trigger>
         <dropdown.Content {{on "focusout" onFocusOut}}><input type="text" id="inner-input"></dropdown.Content>
       </BasicDropdown>


### PR DESCRIPTION
Issue #420 

My attempt at implementing onBeforeOpen, onBeforeClose, onAfterOpen, onAfterClose hooks.

I wasn't sure what arguments should be passed to the "after" hooks and whether or not `onAfterClose` should be called if the dropdown has been destroyed.

Let me know if there are any changes to documentation/implementation or tests you want.

Thanks for the great addon!
