### PR TITLE
Fall back to verticalPosition="below" if there isn't enough space either way

### DIFF
--- a/addon/utils/calculate-position.ts
+++ b/addon/utils/calculate-position.ts
@@ -122,7 +122,9 @@ export let calculateWormholedPosition: CalculatePosition = (trigger, content, de
     let enoughRoomBelow = triggerTopWithScroll + triggerHeight + dropdownHeight < viewportBottom;
     let enoughRoomAbove = triggerTop > dropdownHeight;
 
-    if (previousVerticalPosition === 'below' && !enoughRoomBelow && enoughRoomAbove) {
+    if (!enoughRoomBelow && !enoughRoomAbove) {
+      verticalPosition = 'below';
+    } else if (previousVerticalPosition === 'below' && !enoughRoomBelow && enoughRoomAbove) {
       verticalPosition = 'above';
     } else if (previousVerticalPosition === 'above' && !enoughRoomAbove && enoughRoomBelow) {
       verticalPosition = 'below';


### PR DESCRIPTION
If using auto vertical positioning, and there is not enough space either above or below, the dropdown should always be positioned below - this way, the page will at least expand to show the dropdown, whereas it will be cut off if it moves out of the screen above.

Fixes #505 
