### PR TITLE
BUGFIX Content didn't reposition after scroll or resize events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- [BUGFIX] Fix reposition of dropdown after scroll or window resize events
+
 # 3.0.0-beta.2
 - [CHORE] Update to @glimmer/component 1.0.0-beta.2
 

--- a/addon/components/basic-dropdown-content.js
+++ b/addon/components/basic-dropdown-content.js
@@ -74,7 +74,7 @@ export default class BasicDropdownContent extends Component {
 
   get style() {
     let style = '';
-    let { top, left, right, width, height, otherStyles } = this;
+    let { top, left, right, width, height, otherStyles } = this.args;
 
     if (otherStyles) {
       Object.keys(otherStyles).forEach((attr) => {


### PR DESCRIPTION
It turns out the top/left/right/width/height properties passed to the dropdown weren't
being used at all