### PR TITLE
fix otherStyles changes

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -150,7 +150,7 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
     let changes = {
       hPosition: positions.horizontalPosition,
       vPosition: positions.verticalPosition,
-      otherStyles: this.otherStyles
+      otherStyles: Object.assign({}, this.otherStyles)
     };
 
     if (positions.style) {


### PR DESCRIPTION
The problem here was that the `otherStyles` property was being mutated here https://github.com/cibernox/ember-basic-dropdown/blob/v3/addon/components/basic-dropdown.js#L182

On the next reposition, those styles would be there and could result in unexpected behavior.