### PR TITLE
ignore comment node changes on mutation observer

### DIFF
--- a/addon/components/basic-dropdown-content.js
+++ b/addon/components/basic-dropdown-content.js
@@ -177,7 +177,17 @@ export default @layout(templateLayout) @tagName('')class BasicDropdownContent ex
   @action
   setupMutationObserver(dropdownElement) {
     this.mutationObserver = new MutationObserver((mutations) => {
-      if (mutations[0].addedNodes.length || mutations[0].removedNodes.length) {
+      let shouldReposition = false;
+
+      shouldReposition = Array.prototype.slice.call(mutations[0].addedNodes).some((node) => {
+        return node.nodeName !== '#comment' && !(node.nodeName === '#text' && node.nodeValue === '');
+      });
+
+      shouldReposition = shouldReposition || Array.prototype.slice.call(mutations[0].removedNodes).some((node) => {
+        return node.nodeName !== '#comment' && !(node.nodeName === '#text' && node.nodeValue === '');
+      });
+
+      if (shouldReposition) {
         this.runloopAwareReposition();
       }
     });


### PR DESCRIPTION
Ember uses comment nodes to keep track of the component boundaries.
I was detecting some unneeded repositions because the mutation observers were detecting these comment nodes insertions/deletions.

I also went ahead and filtered out empty text nodes as well.

`Array.prototype.slice.call` was used to convert a `NodeList` to an array because it is faster than `Array.from()`. Source: https://stackoverflow.com/a/49822981