### PR TITLE
reset `otherStyles` on closing

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -109,7 +109,7 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
     if (this.isDestroyed) {
       return; // To check that the `onClose` didn't destroy the dropdown
     }
-    this.setProperties({ hPosition: null, vPosition: null, top: null, left: null, right: null, width: null, height: null });
+    this.setProperties({ hPosition: null, vPosition: null, top: null, left: null, right: null, width: null, height: null, otherStyles: {} });
     this.previousVerticalPosition = this.previousHorizontalPosition = null;
     this.updateState({ isOpen: false });
     if (skipFocus) {


### PR DESCRIPTION
This is very important because some position calculations might rely on the existing dimensions.
If we don't reset otherStyles, the dropdown is rendered with the previously applied styles, which might affect the position calculation.