### PR TITLE
Support custom positioning using `bottom` property

### DIFF
--- a/addon/components/basic-dropdown-content.js
+++ b/addon/components/basic-dropdown-content.js
@@ -79,10 +79,10 @@ export default @layout(templateLayout) @tagName('')class BasicDropdownContent ex
     return document.getElementById(this.destination);
   }
 
-  @computed('top', 'left', 'right', 'width', 'height', 'otherStyles')
+  @computed('top', 'bottom', 'left', 'right', 'width', 'height', 'otherStyles')
   get style() {
     let style = '';
-    let { top, left, right, width, height, otherStyles } = this;
+    let { top, bottom, left, right, width, height, otherStyles } = this;
 
     if (otherStyles) {
       Object.keys(otherStyles).forEach((attr) => {
@@ -92,6 +92,9 @@ export default @layout(templateLayout) @tagName('')class BasicDropdownContent ex
 
     if (top) {
       style += `top: ${top};`;
+    }
+    if (bottom) {
+      style += `bottom: ${bottom};`;
     }
     if (left) {
       style += `left: ${left};`;

--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -13,6 +13,7 @@ import requirejs from 'require';
 
 const ignoredStyleAttrs = [
   'top',
+  'bottom',
   'left',
   'right',
   'width',
@@ -21,6 +22,7 @@ const ignoredStyleAttrs = [
 
 export default @layout(templateLayout) @tagName('') class BasicDropdown extends Component {
   top = null;
+  bottom = null;
   left = null;
   right = null;
   width = null;
@@ -112,6 +114,7 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
       hPosition: null,
       vPosition: null,
       top: null,
+      bottom: null,
       left: null,
       right: null,
       width: null,
@@ -163,8 +166,17 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
     };
 
     if (positions.style) {
+      // The component can be aligned from the top or from the bottom, but not from both.
       if (positions.style.top !== undefined) {
         changes.top = `${positions.style.top}px`;
+        changes.bottom = null;
+        // Since we set the first run manually we may need to unset the `bottom` property.
+        if (positions.style.bottom !== undefined) {
+          positions.style.bottom = undefined;
+        }
+      } else if (positions.style.bottom !== undefined) {
+        changes.bottom = `${positions.style.bottom}px`;
+        changes.top = null;
       }
       // The component can be aligned from the right or from the left, but not from both.
       if (positions.style.left !== undefined) {
@@ -193,7 +205,7 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
         }
       });
 
-      if (this.top === null) {
+      if (this.top === null && this.bottom === null) {
         // Bypass Ember on the first reposition only to avoid flickering.
         let cssRules = [];
         for (let prop in positions.style) {

--- a/addon/templates/components/basic-dropdown.hbs
+++ b/addon/templates/components/basic-dropdown.hbs
@@ -21,6 +21,7 @@
       vPosition=(readonly this.vPosition)
       destination=(readonly this.destination)
       top=(readonly this.top)
+      bottom=(readonly this.bottom)
       left=(readonly this.left)
       right=(readonly this.right)
       width=(readonly this.width)

--- a/addon/utils/calculate-position.js
+++ b/addon/utils/calculate-position.js
@@ -15,7 +15,7 @@
   @return {Object} How the component is going to be positioned.
     - {String} horizontalPosition The new horizontal position.
     - {String} verticalPosition The new vertical position.
-    - {Object} CSS properties to be set on the dropdown. It supports `top`, `left`, `right` and `width`.
+    - {Object} CSS properties to be set on the dropdown. It supports `top`, `bottom`, `left`, `right`, `width` and `height`.
 */
 export default function(_, _2, _destination, { renderInPlace }) {
   if (renderInPlace) {

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -21,7 +21,7 @@
     <tr>
       <td>calculatePosition</td>
       <td><code>Function</code></td>
-      <td>Fuction to customize how the content of the dropdown is positioned.</td>
+      <td>Fuction to customize how the content of the dropdown is positioned. (See {{#link-to "public-pages.docs.custom-position"}}Custom Position{{/link-to}})</td>
     </tr>
     <tr>
       <td>class</td>

--- a/tests/dummy/app/templates/public-pages/docs/custom-position.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/custom-position.hbs
@@ -49,7 +49,7 @@
 <ul>
   <li><code>horizontalPosition</code>: The new value of horizontalPosition</li>
   <li><code>verticalPosition</code>: The new value of verticalPosition</li>
-  <li><code>style</code>: An object containing the CSS properties that will position the object. It supports <code>top</code>, <code>left</code>, <code>right</code> and <code>width</code></li>
+  <li><code>style</code>: An object containing the CSS properties that will position the object. It supports <code>top</code>, <code>bottom</code>, <code>left</code>, <code>right</code>, <code>width</code> and <code>height</code>.</li>
 </ul>
 
 <p>

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -29,6 +29,17 @@ module('Integration | Component | basic-dropdown-content', function(hooks) {
     assert.dom('.ember-basic-dropdown-content').hasText('Lorem ipsum', 'It contains the given block');
     assert.dom('.ember-basic-dropdown-content').hasClass('extra-class');
   });
+  test('If `@top`, `@bottom`, `@left`, `@right`, `@width`, `@height` or `@otherStyles` arguments are provided, then those styles are reflected on the content’s element', async function(assert) {
+    assert.expect(2);
+    this.dropdown = { uniqueId: 'e123', isOpen: true, actions: { reposition() { } } };
+    this.otherStyles = { display: 'flex', 'align-items': 'center' };
+    await render(hbs`
+      <div id="destination-el"></div>
+      <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el" @top="10px" @bottom="20px" @left="30px" @right="40px" @width="50px" @height="60px" @otherStyles={{hash display="flex" align-items="center"}}>Lorem ipsum</BasicDropdownContent>
+    `);
+    assert.dom('.ember-basic-dropdown-content').hasText('Lorem ipsum', 'It contains the given block');
+    assert.dom('.ember-basic-dropdown-content').hasAttribute('style', 'display: flex;align-items: center;top: 10px;bottom: 20px;left: 30px;right: 40px;width: 50px;height: 60px');
+  });
 
   test('If the dropdown is closed, nothing is rendered', async function(assert) {
     assert.expect(1);


### PR DESCRIPTION
This adds support for handling `style.bottom` if it’s returned from `calculatePosition()`.

`top`, `left` and `right` are already supported, so now with `bottom` we have the complete set! 🙂