### PR TITLE
Fix animationEnabled getter to account for false value

### DIFF
--- a/addon/components/basic-dropdown-content.js
+++ b/addon/components/basic-dropdown-content.js
@@ -62,7 +62,7 @@ export default @layout(templateLayout) @tagName('')class BasicDropdownContent ex
   // CPs
   @computed
   get animationEnabled() {
-    if ('_animationEnabled' in this) {
+    if (this._animationEnabled !== 'undefined') {
       return this._animationEnabled;
     }
 

--- a/addon/components/basic-dropdown-content.js
+++ b/addon/components/basic-dropdown-content.js
@@ -62,7 +62,7 @@ export default @layout(templateLayout) @tagName('')class BasicDropdownContent ex
   // CPs
   @computed
   get animationEnabled() {
-    if (this._animationEnabled) {
+    if ('_animationEnabled' in this) {
       return this._animationEnabled;
     }
 


### PR DESCRIPTION
If `@animationEnabled={{false}}` is passed, the getter will not use it