### PR TITLE
Always call _super.included

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,18 +5,20 @@ module.exports = {
 
   included(appOrAddon) {
     let app = appOrAddon.app || appOrAddon;
-    if (!app.__emberBasicDropdownIncludedInvoked) {
-      app.__emberBasicDropdownIncludedInvoked = true;
+    if (app.__emberBasicDropdownIncludedInvoked) {
       this._super.included.apply(this, arguments);
+      return;
+    }
+    app.__emberBasicDropdownIncludedInvoked = true;
+    this._super.included.apply(this, arguments);
 
-      let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];
-      let hasLess = !!app.registry.availablePlugins['ember-cli-less'];
+    let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];
+    let hasLess = !!app.registry.availablePlugins['ember-cli-less'];
 
-      // Don't include the precompiled css file if the user uses a supported CSS preprocessor
-      if (!hasSass && !hasLess) {
-        if (!app.__skipEmberBasicDropdownStyles) {
-          app.import('vendor/ember-basic-dropdown.css');
-        }
+    // Don't include the precompiled css file if the user uses a supported CSS preprocessor
+    if (!hasSass && !hasLess) {
+      if (!app.__skipEmberBasicDropdownStyles) {
+        app.import('vendor/ember-basic-dropdown.css');
       }
     }
   },


### PR DESCRIPTION
Fixes #544

After updating `ember-power-select` to `4.0.0` our app was erroring with:

> Could not find module `ember-compatibility-helpers` imported from `@glimmer/component/index`

Replicated the changed made in cibernox/ember-power-select/pull/1244

With these changes our app no longer breaks.

