### PR TITLE
use default values if a property (that can come from an argument) has a value that is `undefined`

### DIFF
--- a/addon/components/basic-dropdown.js
+++ b/addon/components/basic-dropdown.js
@@ -20,6 +20,13 @@ const ignoredStyleAttrs = [
   'height'
 ];
 
+const defaultValues = {
+  renderInPlace: false,
+  verticalPosition: 'auto', // above | below
+  horizontalPosition: 'auto', // auto-right | right | center | left
+  matchTriggerWidth: false,
+}
+
 export default @layout(templateLayout) @tagName('') class BasicDropdown extends Component {
   top = null;
   bottom = null;
@@ -29,14 +36,17 @@ export default @layout(templateLayout) @tagName('') class BasicDropdown extends 
   height = null;
   otherStyles = {};
   publicAPI = {};
-  renderInPlace = false;
-  verticalPosition = 'auto'; // above | below
-  horizontalPosition = 'auto'; // auto-right | right | center | left
-  matchTriggerWidth = false;
 
   // Lifecycle hooks
   init() {
+    Object.entries(defaultValues).forEach(([key, value]) => {
+      if(typeof this.get(key) === 'undefined') {
+        this.set(key, value)
+      }
+    })
+
     super.init(...arguments);
+
     let publicAPI = this.updateState({
       uniqueId: guidFor(this),
       isOpen: this.initiallyOpened || false,


### PR DESCRIPTION
This makes it so that the default values are used even if arguments are sent in but if their values are `undefined` the defaults will be used. 

For example `ember-power-select` [always sends some arguments](https://github.com/cibernox/ember-power-select/blob/master/addon/templates/components/power-select.hbs#L2) to `BasicDropdown` which caused the default values to not be used.

This should fix that.

(This pr is done for [v2 branch](https://github.com/cibernox/ember-basic-dropdown/tree/v2) since we cant upgrade to v3 yet because we use https://github.com/cibernox/ember-power-select-with-create which requires `ember-basic-dropdown` v2)