### PR TITLE
Issue 555 - Always set aria-expanded, also when collapsed.

### DIFF
--- a/addon/templates/components/basic-dropdown-trigger.hbs
+++ b/addon/templates/components/basic-dropdown-trigger.hbs
@@ -5,7 +5,7 @@
     tabindex={{unless @dropdown.disabled "0"}}
     data-ebd-id="{{@dropdown.uniqueId}}-trigger"
     aria-owns="ember-basic-dropdown-content-{{@dropdown.uniqueId}}"
-    aria-expanded={{if @dropdown.isOpen "true"}}
+    aria-expanded={{if @dropdown.isOpen "true" "false"}}
     aria-disabled={{if @dropdown.disabled "true"}}
     {{will-destroy this.removeGlobalHandlers}}
     ...attributes

--- a/addon/templates/components/basic-dropdown-trigger.hbs
+++ b/addon/templates/components/basic-dropdown-trigger.hbs
@@ -5,7 +5,7 @@
     tabindex={{unless @dropdown.disabled "0"}}
     data-ebd-id="{{@dropdown.uniqueId}}-trigger"
     aria-owns="ember-basic-dropdown-content-{{@dropdown.uniqueId}}"
-    aria-expanded={{if @dropdown.isOpen "true" "false"}}
+    aria-expanded="{{@dropdown.isOpen}}"
     aria-disabled={{if @dropdown.disabled "true"}}
     {{will-destroy this.removeGlobalHandlers}}
     ...attributes

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -106,13 +106,13 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
     assert.dom('.ember-basic-dropdown-trigger').doesNotHaveAttribute('aria-disabled', 'It is NOT marked as disabled');
   });
 
-  test('If the received dropdown is open, it has an `aria-expanded="true"` attribute', async function(assert) {
+  test('If the received dropdown is open, it has an `aria-expanded="true"` attribute, otherwise `"false"`', async function(assert) {
     assert.expect(2);
     this.dropdown = { uniqueId: 123, isOpen: false };
     await render(hbs`
       <BasicDropdownTrigger @dropdown={{dropdown}}>Click me</BasicDropdownTrigger>
     `);
-    assert.dom('.ember-basic-dropdown-trigger').doesNotHaveAttribute('aria-expanded');
+    assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-expanded', 'false', 'the aria-expanded is false');
     run(() => set(this.dropdown, 'isOpen', true));
     assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-expanded', 'true', 'the aria-expanded is true');
   });


### PR DESCRIPTION
aria-expanded is a property that must always be set when used, to either `"true"` when expanded, or `"false"` if collapsed. Omitting it when collapsed means that assistive technologies aren't aware that this element is expandable.

Closes #555 .