### PR TITLE
Use aria-owns on the trigger's container instead of on the trigger

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -343,7 +343,7 @@ function dropdownIsValidParent(el: Element, dropdownId: string): boolean {
     return false;
   } else {
     let closestAttrs = closestDropdown.attributes as unknown as any
-    let trigger = document.querySelector(`[aria-owns=${closestAttrs.id.value}]`);
+    let trigger = document.querySelector(`[aria-controls=${closestAttrs.id.value}]`);
     if (trigger === null) return false;
     let parentDropdown = closestContent(trigger);
     if (parentDropdown === null) return false;

--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -136,6 +136,11 @@ export default class BasicDropdown extends Component<Args> {
     }
     this.isOpen = true;
     this.args.registerAPI && this.args.registerAPI(this.publicAPI);
+    let trigger = document.querySelector(`[data-ebd-id=${this.publicAPI.uniqueId}-trigger]`) as HTMLElement;
+    if (trigger) {
+      let parent = trigger.parentElement;
+      if (parent) { parent.setAttribute("aria-owns", this._dropdownId); }
+    }
   }
 
   @action
@@ -157,11 +162,16 @@ export default class BasicDropdown extends Component<Args> {
     this.previousVerticalPosition = this.previousHorizontalPosition = undefined;
     this.isOpen = false;
     this.args.registerAPI && this.args.registerAPI(this.publicAPI);
+    let trigger = document.querySelector(`[data-ebd-id=${this.publicAPI.uniqueId}-trigger]`) as HTMLElement;
+    if (!trigger) {
+      return;
+    }
+    let parent = trigger.parentElement;
+    if (parent) { parent.removeAttribute("aria-owns"); }
     if (skipFocus) {
       return;
     }
-    let trigger = document.querySelector(`[data-ebd-id=${this.publicAPI.uniqueId}-trigger]`) as HTMLElement;
-    if (trigger && trigger.tabIndex > -1) {
+    if (trigger.tabIndex > -1) {
       trigger.focus();
     }
   }

--- a/addon/templates/components/basic-dropdown-trigger.hbs
+++ b/addon/templates/components/basic-dropdown-trigger.hbs
@@ -4,7 +4,7 @@
     role="button"
     tabindex={{unless @dropdown.disabled "0"}}
     data-ebd-id="{{@dropdown.uniqueId}}-trigger"
-    aria-owns="ember-basic-dropdown-content-{{@dropdown.uniqueId}}"
+    aria-controls="ember-basic-dropdown-content-{{@dropdown.uniqueId}}"
     aria-expanded="{{@dropdown.isOpen}}"
     aria-disabled={{if @dropdown.disabled "true"}}
     {{will-destroy this.removeGlobalHandlers}}

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -510,6 +510,21 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-controls', content.id, 'The trigger controls the content');
   });
 
+  test('When opened, the `aria-owns` attribute of the trigger parent contains the id of the content', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`
+      <BasicDropdown @renderInPlace={{true}} as |dropdown|>
+        <dropdown.Trigger>Click me</dropdown.Trigger>
+        <dropdown.Content><div id="dropdown-is-opened"></div></dropdown.Content>
+      </BasicDropdown>
+    `);
+    assert.dom(this.element.querySelector('.ember-basic-dropdown-trigger').parentNode).doesNotHaveAttribute('aria-owns', 'Closed dropdown parent does not have aria-owns');
+    await click('.ember-basic-dropdown-trigger');
+    let content = this.element.querySelector('.ember-basic-dropdown-content');
+    assert.dom(this.element.querySelector('.ember-basic-dropdown-trigger').parentNode).hasAttribute('aria-owns', content.id, 'The trigger parent owns the content');
+  });
+
   // Repositioning
   test('Firing a reposition outside of a runloop doesn\'t break the component', async function(assert) {
     let done = assert.async();

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -496,7 +496,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
   });
 
   // A11y
-  test('By default, the `aria-owns` attribute of the trigger contains the id of the content', async function(assert) {
+  test('By default, the `aria-controls` attribute of the trigger contains the id of the content', async function(assert) {
     assert.expect(1);
 
     await render(hbs`
@@ -507,7 +507,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     `);
     await click('.ember-basic-dropdown-trigger');
     let content = this.element.querySelector('.ember-basic-dropdown-content');
-    assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-owns', content.id, 'The trigger controls the content');
+    assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-controls', content.id, 'The trigger controls the content');
   });
 
   // Repositioning

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -117,13 +117,13 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
     assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-expanded', 'true', 'the aria-expanded is true');
   });
 
-  test('If it has an `aria-owns="foo123"` attribute pointing to the id of the content', async function(assert) {
+  test('If it has an `aria-controls="foo123"` attribute pointing to the id of the content', async function(assert) {
     assert.expect(1);
     this.dropdown = { uniqueId: 123 };
     await render(hbs`
       <BasicDropdownTrigger @dropdown={{dropdown}}>Click me</BasicDropdownTrigger>
     `);
-    assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-owns', 'ember-basic-dropdown-content-123');
+    assert.dom('.ember-basic-dropdown-trigger').hasAttribute('aria-controls', 'ember-basic-dropdown-content-123');
   });
 
   test('If it receives `@htmlTag`, the trigger uses that tag name', async function (assert) {


### PR DESCRIPTION
Closes #557.

aria-owns should not be used to make the content elements children of the button, since this is invalid accessibility structure. Screen readers like Orca on Linux don't handle this well.

Instead, use aria-controls to build a relationship between the trigger and content, and add aria-owns to the parent of the trigger so the content gets appended as the last accessible child of that container.