### PR TITLE
fix event type on RootMouseDownHandler

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -31,7 +31,7 @@ interface Args {
   otherStyles: Record<string, string>
   shouldReposition: (mutations: MutationRecord[], dropdown: Dropdown) => boolean
 }
-type RootMouseDownHandler = (ev: MouseEvent) => void
+type RootMouseDownHandler = (ev: MouseEvent | TouchEvent) => void
 
 export default class BasicDropdownContent extends Component<Args> {
   transitioningInClass = this.args.transitioningInClass || 'ember-basic-dropdown--transitioning-in';


### PR DESCRIPTION
This issue was addressed partially in the previous commit: 702f15052bbb124de2a2c9ede6a2dc436e470ffe, however, there's another type definition also have the same problem: https://github.com/cibernox/ember-basic-dropdown/blob/809ac756022a5e2e249bc8cba3ef080b58f440cf/addon/components/basic-dropdown-content.ts#L34 and been used on here: https://github.com/cibernox/ember-basic-dropdown/blob/809ac756022a5e2e249bc8cba3ef080b58f440cf/addon/components/basic-dropdown-content.ts#L126 and here: https://github.com/cibernox/ember-basic-dropdown/blob/809ac756022a5e2e249bc8cba3ef080b58f440cf/addon/components/basic-dropdown-content.ts#L130

This PR is going to fix the remaining type errors and has been tested successfully.

@cibernox I'm sorry that I should've mention there're multiple occurrences of this type error.