### PR TITLE
Updated ember compatibility in the readme to match up with the minimum version that is in the ember-try.js file for version 2 and 1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ or `ember-paper`'s [menu component](http://miguelcobain.github.io/ember-paper/#/
 
 ### Compatibility
 
-Version 2.0 requires Ember 3.11 or greater
-Versions 1.X require Ember 2.12 or greater
+Version 2.0 requires Ember 3.13 or greater
+Versions 1.X require Ember 2.16 or greater
 
 ### Installation
 


### PR DESCRIPTION
The minimum emberjs version for version 2 should be 3.13 as version 2 uses glimmer components and that is only available for emberjs version 3.13 or greater(around the time you were finally able to enable octane before it became the default in 3.16).

For version 1.x, the `ember-try.js` uses emberjs 2.16.0 as it's minimum from what I saw.