### PR TITLE
#498 - Allow overriding built-in event handlers

### DIFF
--- a/addon/templates/components/basic-dropdown-trigger.hbs
+++ b/addon/templates/components/basic-dropdown-trigger.hbs
@@ -8,24 +8,24 @@
     aria-expanded="{{@dropdown.isOpen}}"
     aria-disabled={{if @dropdown.disabled "true"}}
     {{will-destroy this.removeGlobalHandlers}}
-    ...attributes
-    {{on "mousedown" this.handleMouseDown}}
-    {{on "click" this.handleClick}}
-    {{on "keydown" this.handleKeyDown}}
-    {{on "touchstart" this.handleTouchStart}}
-    {{on "touchend" this.handleTouchEnd}}
 
     {{!-- V1 compatibility - See #498 --}}
-    {{on "keydown" (fn (or @onKeyDown this.noop) @dropdown)}}
-    {{on "mousedown" (fn (or @onMouseDown this.noop) @dropdown)}}
-    {{on "touchend" (fn (or @onTouchEnd this.noop) @dropdown)}}
-    {{on "click" (fn (or @onClick this.noop) @dropdown)}}
-    {{on "mouseenter" (fn (or @onMouseEnter this.noop) @dropdown)}}
-    {{on "mouseleave" (fn (or @onMouseLeave this.noop) @dropdown)}}
-    {{on "focus" (fn (or @onFocus this.noop) @dropdown)}}
+    {{!-- Use default handlers as fallback --}}
+    {{on "click" (fn (or @onClick this.handleClick) @dropdown)}}
+    {{on "keydown" (fn (or @onKeyDown this.handleKeyDown) @dropdown)}}
+    {{on "mousedown" (fn (or @onMouseDown this.handleMouseDown) @dropdown)}}
+    {{on "touchend" (fn (or @onTouchEnd this.handleTouchEnd) @dropdown)}}
+    {{on "touchstart" (fn (or @onTouchStart this.handleTouchStart) @dropdown)}}
+
+    {{!-- Use no-ops where we don't have a default handlers --}}
     {{on "blur" (fn (or @onBlur this.noop) @dropdown)}}
+    {{on "focus" (fn (or @onFocus this.noop) @dropdown)}}
     {{on "focusin" (fn (or @onFocusIn this.noop) @dropdown)}}
     {{on "focusout" (fn (or @onFocusOut this.noop) @dropdown)}}
+    {{on "mouseenter" (fn (or @onMouseEnter this.noop) @dropdown)}}
+    {{on "mouseleave" (fn (or @onMouseLeave this.noop) @dropdown)}}
+
+    ...attributes
     >
     {{yield}}
   </Element>

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -619,10 +619,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
     await tap('.ember-basic-dropdown-trigger');
   });
 
-  /**
-   * Tests related to https://github.com/cibernox/ember-basic-dropdown/issues/498
-   * Can be removed when the template `V1` compatability event handlers are removed.
-   */
   module("trigger event handlers", function (hooks) {
     hooks.beforeEach(function () {
       this.set("dropdown", { uniqueId: "e123", actions: { toggle: () => {} } });
@@ -642,6 +638,115 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
       assert.ok(args.length === 2, "It receives only 2 arguments");
     }
 
+    test("It properly handles the onClick action", async function (assert) {
+      assert.expect(5);
+
+      const onClick = function () {
+        assert.ok(true, "The `onClick()` action has been fired");
+        assertCommonEventHandlerArgs.call(this, assert, arguments);
+      };
+
+      this.set("onClick", onClick.bind(this));
+
+      await render(hbs`
+        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onClick={{this.onClick}}>hello</BasicDropdownTrigger>
+      `);
+      await click(".ember-basic-dropdown-trigger");
+      assert
+        .dom(".ember-basic-dropdown-content")
+        .doesNotExist(
+          "The default event handler was overidden and dropdown content was not displayed"
+        );
+    });
+
+    test("It properly handles the onKeyDown action", async function (assert) {
+      assert.expect(5);
+
+      const onKeyDown = function () {
+        assert.ok(true, "The `onKeyDown()` action has been fired");
+        assertCommonEventHandlerArgs.call(this, assert, arguments);
+      };
+
+      this.set("onKeyDown", onKeyDown.bind(this));
+
+      await render(hbs`
+        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onKeyDown={{this.onKeyDown}}>hello</BasicDropdownTrigger>
+      `);
+      await triggerEvent(".ember-basic-dropdown-trigger", "keydown");
+      assert
+        .dom(".ember-basic-dropdown-content")
+        .doesNotExist(
+          "The default event handler was overidden and dropdown content was not displayed"
+        );
+    });
+
+    test("It properly handles the onMouseDown action", async function (assert) {
+      assert.expect(5);
+
+      const onMouseDown = function () {
+        assert.ok(true, "The `onMouseDown()` action has been fired");
+        assertCommonEventHandlerArgs.call(this, assert, arguments);
+      };
+
+      this.set("onMouseDown", onMouseDown.bind(this));
+
+      await render(hbs`
+        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onMouseDown={{this.onMouseDown}}>hello</BasicDropdownTrigger>
+      `);
+      await triggerEvent(".ember-basic-dropdown-trigger", "mousedown");
+      assert
+        .dom(".ember-basic-dropdown-content")
+        .doesNotExist(
+          "The default event handler was overidden and dropdown content was not displayed"
+        );
+    });
+
+    test("It properly handles the onTouchEnd action", async function (assert) {
+      assert.expect(5);
+
+      const onTouchEnd = function () {
+        assert.ok(true, "The `onTouchEnd()` action has been fired");
+        assertCommonEventHandlerArgs.call(this, assert, arguments);
+      };
+
+      this.set("onTouchEnd", onTouchEnd.bind(this));
+
+      await render(hbs`
+        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onTouchEnd={{this.onTouchEnd}}>hello</BasicDropdownTrigger>
+      `);
+      await triggerEvent(".ember-basic-dropdown-trigger", "touchend");
+      assert
+        .dom(".ember-basic-dropdown-content")
+        .doesNotExist(
+          "The default event handler was overidden and dropdown content was not displayed"
+        );
+    });
+
+    test("It properly handles the onTouchStart action", async function (assert) {
+      assert.expect(5);
+
+      const onTouchStart = function () {
+        assert.ok(true, "The `onTouchStart()` action has been fired");
+        assertCommonEventHandlerArgs.call(this, assert, arguments);
+      };
+
+      this.set("onTouchStart", onTouchStart.bind(this));
+
+      await render(hbs`
+        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onTouchStart={{this.onTouchStart}}>hello</BasicDropdownTrigger>
+      `);
+      await triggerEvent(".ember-basic-dropdown-trigger", "touchstart");
+      assert
+        .dom(".ember-basic-dropdown-content")
+        .doesNotExist(
+          "The default event handler was overidden and dropdown content was not displayed"
+        );
+    });
+
+    /**
+     * The following tests related to https://github.com/cibernox/ember-basic-dropdown/issues/498
+     * Can be removed when the template `V1` compatability event handlers are removed.
+     */
     test("It properly handles the onBlur action", async function (assert) {
       assert.expect(4);
 
@@ -656,22 +761,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
         <BasicDropdownTrigger @dropdown={{this.dropdown}} @onBlur={{this.onBlur}}>hello</BasicDropdownTrigger>
       `);
       await triggerEvent(".ember-basic-dropdown-trigger", "blur"); // For some reason, `blur` test-helper fails here
-    });
-
-    test("It properly handles the onClick action", async function (assert) {
-      assert.expect(4);
-
-      const onClick = function () {
-        assert.ok(true, "The `onClick()` action has been fired");
-        assertCommonEventHandlerArgs.call(this, assert, arguments);
-      };
-
-      this.set("onClick", onClick.bind(this));
-
-      await render(hbs`
-        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onClick={{this.onClick}}>hello</BasicDropdownTrigger>
-      `);
-      await click(".ember-basic-dropdown-trigger");
     });
 
     test("It properly handles the onFocus action", async function (assert) {
@@ -722,38 +811,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
       await triggerEvent(".ember-basic-dropdown-trigger", "focusout");
     });
 
-    test("It properly handles the onKeyDown action", async function (assert) {
-      assert.expect(4);
-
-      const onKeyDown = function () {
-        assert.ok(true, "The `onKeyDown()` action has been fired");
-        assertCommonEventHandlerArgs.call(this, assert, arguments);
-      };
-
-      this.set("onKeyDown", onKeyDown.bind(this));
-
-      await render(hbs`
-        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onKeyDown={{this.onKeyDown}}>hello</BasicDropdownTrigger>
-      `);
-      await triggerEvent(".ember-basic-dropdown-trigger", "keydown");
-    });
-
-    test("It properly handles the onMouseDown action", async function (assert) {
-      assert.expect(4);
-
-      const onMouseDown = function () {
-        assert.ok(true, "The `onMouseDown()` action has been fired");
-        assertCommonEventHandlerArgs.call(this, assert, arguments);
-      };
-
-      this.set("onMouseDown", onMouseDown.bind(this));
-
-      await render(hbs`
-        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onMouseDown={{this.onMouseDown}}>hello</BasicDropdownTrigger>
-      `);
-      await triggerEvent(".ember-basic-dropdown-trigger", "mousedown");
-    });
-
     test("It properly handles the onMouseEnter action", async function (assert) {
       assert.expect(4);
 
@@ -784,22 +841,6 @@ module('Integration | Component | basic-dropdown-trigger', function(hooks) {
         <BasicDropdownTrigger @dropdown={{this.dropdown}} @onMouseLeave={{this.onMouseLeave}}>hello</BasicDropdownTrigger>
       `);
       await triggerEvent(".ember-basic-dropdown-trigger", "mouseleave");
-    });
-
-    test("It properly handles the onTouchEnd action", async function (assert) {
-      assert.expect(4);
-
-      const onTouchEnd = function () {
-        assert.ok(true, "The `onTouchEnd()` action has been fired");
-        assertCommonEventHandlerArgs.call(this, assert, arguments);
-      };
-
-      this.set("onTouchEnd", onTouchEnd.bind(this));
-
-      await render(hbs`
-        <BasicDropdownTrigger @dropdown={{this.dropdown}} @onTouchEnd={{this.onTouchEnd}}>hello</BasicDropdownTrigger>
-      `);
-      await triggerEvent(".ember-basic-dropdown-trigger", "touchend");
     });
   });
 });


### PR DESCRIPTION
Followup to https://github.com/cibernox/ember-basic-dropdown/pull/499

During testing https://github.com/cibernox/ember-basic-dropdown/pull/499, I noticed that it's not possible to override the behaviour of the built in event handlers. For example, to make the dropdown only appear on hover instead of click.

This PR allows passing any of the following args to override the built in event handlers instead of augment them (as https://github.com/cibernox/ember-basic-dropdown/pull/499 previously allowed):

- `@onClick`
- `@onKeyDown`
- `@onMouseDown`
- `@onTouchEnd`
- `@onTouchStart`

It's still possible to augment the existing event handlers by using the `{{on ...}}` modifier (however, this is not available when yielding an instance of the EBD Trigger using the component helper).

