### PR TITLE
Widen `ember-truth-helpers` dependency constraint to allow v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ember-cli-typescript": "^3.1.2",
     "ember-element-helper": "^0.2.0",
     "ember-maybe-in-element": "^2.0.1",
-    "ember-truth-helpers": "2.1.0"
+    "ember-truth-helpers": "^2.1.0 || ^3.0.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This avoids users having to use `resolutions` to update to ember-truth-helpers v3 :)

