### PR TITLE
CSP-safe positioning

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -3,7 +3,6 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { join } from '@ember/runloop';
 import { getOwner } from '@ember/application';
-import { htmlSafe } from '@ember/string';
 import { getScrollParent } from '../utils/calculate-position';
 import {
   distributeScroll,
@@ -12,7 +11,6 @@ import {
 } from '../utils/scroll-helpers';
 import hasMoved from '../utils/has-moved';
 import { Dropdown } from './basic-dropdown';
-import { SafeString } from "@ember/template/-private/handlebars";
 
 interface Args {
   transitioningInClass?: string
@@ -58,35 +56,6 @@ export default class BasicDropdownContent extends Component<Args> {
   get animationEnabled(): boolean {
     let config = getOwner(this).resolveRegistration('config:environment');
     return config.environment !== 'test';
-  }
-
-  get style(): SafeString {
-    let style = '';
-    let { top, left, right, width, height, otherStyles } = this.args;
-
-    if (otherStyles !== undefined) {
-      for (let attr in otherStyles) {
-        let value = otherStyles[attr];
-        style += `${attr}: ${value};`;
-      }
-    }
-
-    if (top) {
-      style += `top: ${top};`;
-    }
-    if (left) {
-      style += `left: ${left};`;
-    }
-    if (right) {
-      style += `right: ${right};`;
-    }
-    if (width) {
-      style += `width: ${width};`;
-    }
-    if (height) {
-      style += `height: ${height}`;
-    }
-    return htmlSafe(style);
   }
 
   /**

--- a/addon/templates/components/basic-dropdown-content.hbs
+++ b/addon/templates/components/basic-dropdown-content.hbs
@@ -40,5 +40,5 @@
     {{/maybe-in-element}}
   </div>
 {{else}}
-  <div id={{this.dropdownId}} class="ember-basic-dropdown-content-placeholder" style="display: none;"></div>
+<div id={{this.dropdownId}} class="ember-basic-dropdown-content-placeholder" {{style (hash display="none")}}></div>
 {{/if}}

--- a/addon/templates/components/basic-dropdown-content.hbs
+++ b/addon/templates/components/basic-dropdown-content.hbs
@@ -9,7 +9,6 @@
         <Element
           id={{this.dropdownId}}
           class="ember-basic-dropdown-content ember-basic-dropdown-content--{{@hPosition}} ember-basic-dropdown-content--{{@vPosition}} {{this.animationClass}}{{if @renderInPlace " ember-basic-dropdown-content--in-place"}} {{@defaultClass}}"
-          style={{this.style}}
           dir={{@dir}}
           {{did-insert this.setup}}
           {{did-insert @dropdown.actions.reposition}}
@@ -24,6 +23,16 @@
           {{on "focusout" (fn (or @onFocusOut this.noop) @dropdown)}}
           {{on "mouseenter" (fn (or @onMouseEnter this.noop) @dropdown)}}
           {{on "mouseleave" (fn (or @onMouseLeave this.noop) @dropdown)}}
+          {{style
+            @otherStyles
+            (hash
+              top=@top
+              left=@left
+              right=@right
+              width=@width
+              height=@height
+            )
+          }}
           ...attributes>
           {{yield}}
         </Element>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7329,7 +7329,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.2.tgz",
       "integrity": "sha512-9t+ya+9c+FkNM5IAyJIv6ETG8jfZQaUnFCO5SeLlV0wkSw7TOexyb61jh5GVee0KmknfRhrRGGAyT4Y0TwkZ+w==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.22.1",
         "ember-cli-version-checker": "^5.1.1",
@@ -7340,7 +7339,6 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
           "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
-          "dev": true,
           "requires": {
             "resolve-package-path": "^2.0.0",
             "semver": "^7.3.2",
@@ -7351,7 +7349,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
           "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
-          "dev": true,
           "requires": {
             "path-root": "^0.1.1",
             "resolve": "^1.13.1"
@@ -7361,7 +7358,6 @@
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -8490,7 +8486,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.1.tgz",
       "integrity": "sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.22.1",
         "ember-cli-normalize-entity-name": "^1.0.0",
@@ -8840,7 +8835,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-0.6.0.tgz",
       "integrity": "sha512-KqW4vyR80l/GMJsuFV+WLqTmGjXKLpoQ/HAmno+oMDrMt13p/5ImrvarQ6lFgXttFnLCxl6YpMY4YX27p1G54g==",
-      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.21.0",
         "ember-modifier": "^2.1.0"
@@ -12958,7 +12952,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -17843,8 +17836,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yam": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7325,6 +7325,49 @@
         "ember-maybe-import-regenerator": "^0.1.6"
       }
     },
+    "ember-destroyable-polyfill": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.2.tgz",
+      "integrity": "sha512-9t+ya+9c+FkNM5IAyJIv6ETG8jfZQaUnFCO5SeLlV0wkSw7TOexyb61jh5GVee0KmknfRhrRGGAyT4Y0TwkZ+w==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.22.1",
+        "ember-cli-version-checker": "^5.1.1",
+        "ember-compatibility-helpers": "^1.2.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.1.tgz",
+          "integrity": "sha512-YziSW1MgOuVdJSyUY2CKSC4vXrGQIHF6FgygHkJOxYGjZNQYwf5MK0sbliKatvJf7kzDSnXs+r8JLrD74W/A8A==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^7.3.2",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "ember-disable-prototype-extensions": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
@@ -8443,6 +8486,20 @@
         }
       }
     },
+    "ember-modifier": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.1.tgz",
+      "integrity": "sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.22.1",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-typescript": "^3.1.3",
+        "ember-destroyable-polyfill": "^2.0.2",
+        "ember-modifier-manager-polyfill": "^1.2.0"
+      }
+    },
     "ember-modifier-manager-polyfill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
@@ -8777,6 +8834,16 @@
       "dev": true,
       "requires": {
         "got": "^8.0.1"
+      }
+    },
+    "ember-style-modifier": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-0.6.0.tgz",
+      "integrity": "sha512-KqW4vyR80l/GMJsuFV+WLqTmGjXKLpoQ/HAmno+oMDrMt13p/5ImrvarQ6lFgXttFnLCxl6YpMY4YX27p1G54g==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.21.0",
+        "ember-modifier": "^2.1.0"
       }
     },
     "ember-template-lint": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.20.2",
     "ember-source-channel-url": "^2.0.1",
+    "ember-style-modifier": "^0.6.0",
     "ember-template-lint": "^2.9.1",
     "ember-try": "^1.4.0",
     "eslint": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ember-resolver": "^8.0.0",
     "ember-source": "~3.20.2",
     "ember-source-channel-url": "^2.0.1",
-    "ember-style-modifier": "^0.6.0",
     "ember-template-lint": "^2.9.1",
     "ember-try": "^1.4.0",
     "eslint": "^7.5.0",
@@ -91,6 +90,7 @@
     "ember-cli-typescript": "^3.1.2",
     "ember-element-helper": "^0.2.0",
     "ember-maybe-in-element": "^2.0.1",
+    "ember-style-modifier": "^0.6.0",
     "ember-truth-helpers": "^2.1.0 || ^3.0.0"
   },
   "ember": {

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -618,7 +618,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     await click('.ember-basic-dropdown-trigger');
     assert.dom('.ember-basic-dropdown-content').hasClass('ember-basic-dropdown-content--above', 'The dropdown is above');
     assert.dom('.ember-basic-dropdown-content').hasClass('ember-basic-dropdown-content--right', 'The dropdown is in the right');
-    assert.dom('.ember-basic-dropdown-content').hasAttribute('style', 'top: 111px;right: 222px;', 'The style attribute is the expected one');
+    assert.dom('.ember-basic-dropdown-content').hasStyle({ top: '111px', right: '222px' }, 'The style attribute is the expected one');
   });
 
   // Customization of inner components


### PR DESCRIPTION
Currently the positioning of the basic dropdown content requires you to use an `unsafe-inline` directive if you're using a [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). This PR changes the positioning of the content from an inline, html-safe string to using https://github.com/jelhan/ember-style-modifier which adds the styles in a CSP-friendly way.

I'm not sure if you're interested in this change as it brings in a few deps, and I'm not sure what your compatibility story is. I think it's worth it and I believe the change is non-breaking.

Thanks!