### PR TITLE
use style modifier in the content else block too

### DIFF
--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -246,17 +246,15 @@ export default class BasicDropdown extends Component<Args> {
       }
       if (this.top === undefined) {
         // Bypass Ember on the first reposition only to avoid flickering.
-        let cssRules = [];
         for (let prop in positions.style) {
           if (positions.style[prop] !== undefined) {
             if (typeof positions.style[prop] === 'number') {
-              cssRules.push(`${prop}: ${positions.style[prop]}px`)
+              dropdown.style.setProperty(prop, `${positions.style[prop]}px`);
             } else {
-              cssRules.push(`${prop}: ${positions.style[prop]}`)
+              dropdown.style.setProperty(prop, `${positions.style[prop]}`);
             }
           }
         }
-        dropdown.setAttribute('style', cssRules.join(';'));
       }
     }
     for (let prop in positions.style) {

--- a/addon/templates/components/basic-dropdown-content.hbs
+++ b/addon/templates/components/basic-dropdown-content.hbs
@@ -10,6 +10,16 @@
         <Element
           id={{this.dropdownId}}
           class="ember-basic-dropdown-content ember-basic-dropdown-content--{{@hPosition}} ember-basic-dropdown-content--{{@vPosition}} {{this.animationClass}}{{if @renderInPlace " ember-basic-dropdown-content--in-place"}} {{@defaultClass}}"
+          {{style
+            @otherStyles
+            (hash
+              top=@top
+              left=@left
+              right=@right
+              width=@width
+              height=@height
+            )
+          }}
           dir={{@dir}}
           {{did-insert this.setup}}
           {{did-insert @dropdown.actions.reposition}}
@@ -24,6 +34,15 @@
           {{on "focusout" (fn (or @onFocusOut this.noop) @dropdown)}}
           {{on "mouseenter" (fn (or @onMouseEnter this.noop) @dropdown)}}
           {{on "mouseleave" (fn (or @onMouseLeave this.noop) @dropdown)}}
+          ...attributes>
+          {{yield}}
+        </Element>
+      {{/let}}
+      {{else}}
+      {{#let (element @htmlTag) as |Element|}}
+        <Element
+          id={{this.dropdownId}}
+          class="ember-basic-dropdown-content ember-basic-dropdown-content--{{@hPosition}} ember-basic-dropdown-content--{{@vPosition}} {{this.animationClass}}{{if @renderInPlace " ember-basic-dropdown-content--in-place"}} {{@defaultClass}}"
           {{style
             @otherStyles
             (hash
@@ -34,16 +53,6 @@
               height=@height
             )
           }}
-          ...attributes>
-          {{yield}}
-        </Element>
-      {{/let}}
-      {{else}}
-      {{#let (element @htmlTag) as |Element|}}
-        <Element
-          id={{this.dropdownId}}
-          class="ember-basic-dropdown-content ember-basic-dropdown-content--{{@hPosition}} ember-basic-dropdown-content--{{@vPosition}} {{this.animationClass}}{{if @renderInPlace " ember-basic-dropdown-content--in-place"}} {{@defaultClass}}"
-          style={{this.style}}
           dir={{@dir}}
           {{did-insert this.setup}}
           {{did-insert @dropdown.actions.reposition}}

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -580,7 +580,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
     await click('.ember-basic-dropdown-trigger');
     assert.dom('.ember-basic-dropdown-content').hasClass('ember-basic-dropdown-content--above', 'The dropdown is above');
     assert.dom('.ember-basic-dropdown-content').hasClass('ember-basic-dropdown-content--right', 'The dropdown is in the right');
-    assert.dom('.ember-basic-dropdown-content').hasAttribute('style', 'top: 111px;width: 100px;height: 110px', 'The style attribute is the expected one');
+    assert.dom('.ember-basic-dropdown-content').hasAttribute('style', 'top: 111px; width: 100px; height: 110px;', 'The style attribute is the expected one');
   });
 
   test('The user can use the `renderInPlace` flag option to modify how the position is calculated in the `calculatePosition` function', async function(assert) {
@@ -798,8 +798,7 @@ module('Integration | Component | basic-dropdown', function(hooks) {
       </BasicDropdown>
     `);
     await click('.ember-basic-dropdown-trigger');
-    let content = document.querySelector('.ember-basic-dropdown-content');
-    assert.equal(content.getAttribute('style').indexOf('undefined'), -1 , 'There is no undefined values')
+    assert.dom('.ember-basic-dropdown-content').doesNotHaveAttribute('style');
   });
 
   test('It includes the inline styles returned from the `calculatePosition` callback', async function(assert) {
@@ -819,6 +818,6 @@ module('Integration | Component | basic-dropdown', function(hooks) {
       </BasicDropdown>
     `);
     await click('.ember-basic-dropdown-trigger');
-    assert.dom('.ember-basic-dropdown-content').hasAttribute('style', /max-height: 500px;overflow-y: auto/)
+    assert.dom('.ember-basic-dropdown-content').hasAttribute('style', /max-height: 500px; overflow-y: auto/)
   });
 });


### PR DESCRIPTION
In  #591 I aimed to make this work with a strict CSP, and it did for the most part. We got around to using it (via ember-power-select) and were still seeing a few errors.

This adds the same `{{style}}` modifier usage to the `<Element>` rendered if `@htmlTag` is passed.
The initial opening now uses `element.style.setProperty` instead of `element.setAttribute` which is not CSP-safe.