### PR TITLE
Use `@embroider/macros` to conditionally import `@ember/test-helpers`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+.eslintcache

--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -2,7 +2,6 @@ import { action } from "@ember/object";
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { join } from '@ember/runloop';
-import { getOwner } from '@ember/application';
 import { getScrollParent } from '../utils/calculate-position';
 import {
   distributeScroll,
@@ -11,6 +10,7 @@ import {
 } from '../utils/scroll-helpers';
 import hasMoved from '../utils/has-moved';
 import { Dropdown } from './basic-dropdown';
+import { isTesting } from '@embroider/macros';
 
 interface Args {
   transitioningInClass?: string
@@ -54,8 +54,7 @@ export default class BasicDropdownContent extends Component<Args> {
   }
 
   get animationEnabled(): boolean {
-    let config = getOwner(this).resolveRegistration('config:environment');
-    return config.environment !== 'test';
+    return !isTesting(); 
   }
 
   /**

--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -4,11 +4,11 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
-import { DEBUG } from '@glimmer/env';
 import calculatePosition, { CalculatePosition, CalculatePositionResult } from '../utils/calculate-position';
 // @ts-ignore
 import requirejs from 'require';
 import { schedule } from '@ember/runloop';
+import { macroCondition, isTesting } from '@embroider/macros';
 declare const FastBoot: any
 
 export interface DropdownActions {
@@ -281,8 +281,8 @@ export default class BasicDropdown extends Component<Args> {
   _getDestinationId(): string {
     let config = getOwner(this).resolveRegistration('config:environment');
     let id: string;
-    if (config.environment === 'test' && (typeof FastBoot === 'undefined')) {
-      if (DEBUG) {
+    if (macroCondition(isTesting())) {
+      if (typeof FastBoot === 'undefined') {
         if (requirejs.has('@ember/test-helpers/dom/get-root-element')) {
           try {
             return requirejs('@ember/test-helpers/dom/get-root-element').default().id as string;

--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -5,10 +5,8 @@ import { guidFor } from '@ember/object/internals';
 import { getOwner } from '@ember/application';
 import { assign } from '@ember/polyfills';
 import calculatePosition, { CalculatePosition, CalculatePositionResult } from '../utils/calculate-position';
-// @ts-ignore
-import requirejs from 'require';
 import { schedule } from '@ember/runloop';
-import { macroCondition, isTesting } from '@embroider/macros';
+import { macroCondition, isTesting, dependencySatisfies, importSync } from '@embroider/macros';
 declare const FastBoot: any
 
 export interface DropdownActions {
@@ -279,28 +277,32 @@ export default class BasicDropdown extends Component<Args> {
   }
 
   _getDestinationId(): string {
-    let config = getOwner(this).resolveRegistration('config:environment');
-    let id: string;
+    let config = getOwner(this).resolveRegistration("config:environment");
+
+    // This takes care of stripping this code out if not running tests
     if (macroCondition(isTesting())) {
-      if (typeof FastBoot === 'undefined') {
-        if (requirejs.has('@ember/test-helpers/dom/get-root-element')) {
-          try {
-            return requirejs('@ember/test-helpers/dom/get-root-element').default().id as string;
-          } catch(ex) {
-            // no op
-          }
-        }
-        let rootView = document.querySelector('#ember-testing > .ember-view');
+      if (
+        typeof FastBoot === "undefined" &&
+        dependencySatisfies("@ember/test-helpers", ">= 1")
+      ) {
+        let getRootElement = importSync(
+          "@ember/test-helpers/dom/get-root-element"
+        ) as any;
+
+        return getRootElement.default().id;
+      } 
+
+      let rootView = document.querySelector('#ember-testing > .ember-view');
         if (rootView) {
           return rootView.id;
         }
+
         return '';
-      }
     }
-    id = (config['ember-basic-dropdown'] && config['ember-basic-dropdown'].destination || 'ember-basic-dropdown-wormhole') as string;
-    // if (DEBUG && typeof FastBoot === 'undefined' && !this.renderInPlace) {
-    //   assert(`You're trying to attach the content of a dropdown to an node with ID ${id}, but there is no node with that ID in the document. This can happen when your Ember app is not in control of the index.html page. Check https://ember-power-select.com/docs/troubleshooting for more information`, document.getElementById(id));
-    // }
-    return id;
+
+    return ((config["ember-basic-dropdown"] &&
+      config["ember-basic-dropdown"].destination) ||
+      "ember-basic-dropdown-wormhole") as string;
   }
+
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-basic-dropdown",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
+    "@ember/test-helpers": "^1.7.1",
     "@types/ember": "^3.1.1",
     "@types/ember-qunit": "^3.4.7",
     "@types/ember__test-helpers": "^0.7.9",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
+    "@embroider/macros": "^0.36.0",
     "@embroider/util": "^0.36.0",
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.1",

--- a/tests/integration/components/content-test.js
+++ b/tests/integration/components/content-test.js
@@ -496,7 +496,7 @@ module('Integration | Component | basic-dropdown-content', function(hooks) {
         }
       }
     };
-    let divVisible = false;
+    this.divVisible = false;
     await render(hbs`
       <div id="destination-el"></div>
       <BasicDropdownContent @dropdown={{dropdown}} @destination="destination-el">


### PR DESCRIPTION
The current way to conditionally import `@ember/test-helpers/dom/get-root-element` breaks in an app using embroider with:

```
staticAddonTestSupportTrees: true
```

This PR refactors this to instead use `@embroider/macros`, which can be statically analyzed. Functionally, nothing should change, I think. I tried it in an app and it worked fine.