### PR TITLE
Add current Ember LTS versions (3.20 and 3.24) to ember-try config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       matrix:
         ember-try-scenario:
           - ember-3.13
+          - ember-lts-3.20
+          - ember-lts-3.24
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -14,6 +14,22 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.5',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.3',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This updates the ember-try config to include the current (as of this PR) LTS versions of Ember (in addition to the existing scenarios of Ember 3.13, current release, beta, and canary). I noticed in #607 that the tests were failing with versions of Ember between 3.16 and 3.24, while they passed with 3.13 and 3.25.

This will require some effort going forward to keep the LTS scenarios in sync with the current LTS versions of Ember but they don't change very often so there won't be a lot of churn on that account.