### PR TITLE
Allow ember-element-helper ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.3.2",
     "ember-cli-typescript": "^4.1.0",
-    "ember-element-helper": "^0.3.2",
+    "ember-element-helper": "^0.3.2 || ^0.4.0",
     "ember-maybe-in-element": "^2.0.2",
     "ember-style-modifier": "^0.6.0",
     "ember-truth-helpers": "^2.1.0 || ^3.0.0"


### PR DESCRIPTION
To allow host apps to update this dependency. There aren't really any breaking changes as far as I can see (see dependabot screenshot from one of our apps below):

![Screenshot from 2021-04-06 09-26-57](https://user-images.githubusercontent.com/2411343/113674237-44f62e80-96ba-11eb-87a7-68940ee7c534.png)
