### PR TITLE
Add a test demonstrating no-trigger bug

### DIFF
--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -619,6 +619,36 @@ module('Integration | Component | basic-dropdown', function (hooks) {
       );
   });
 
+  // Cookbook examples
+  test('The dropdown can be used without a trigger by invoking toggle and specifying `data-ebd-id`', async function (assert) {
+    assert.expect(4);
+
+    await render(hbs`
+      <BasicDropdown as |dd|>
+        <button id="custom-trigger" {{on "click" dd.actions.toggle}}>Click me</button>
+        <input type="text" data-ebd-id="{{dd.uniqueId}}-trigger">
+        <dd.Content><span id="dropdown-is-open">I am content</span></dd.Content>
+      </BasicDropdown>
+      <div id="outside-element">I am outside the dropdown</div>
+    `);
+
+    // clicking outside should close the content
+    await click('#custom-trigger');
+    assert.dom('#dropdown-is-open').exists('The dropdown is open');
+    await click('#outside-element');
+    assert
+      .dom('#dropdown-is-open')
+      .doesNotExist('The dropdown is closed from outside click');
+
+    // clicking the trigger should toggle the content
+    await click('#custom-trigger');
+    assert.dom('#dropdown-is-open').exists('The dropdown is open again');
+    await click('#custom-trigger');
+    assert
+      .dom('#dropdown-is-open')
+      .doesNotExist('The dropdown is closed from trigger click');
+  });
+
   // A11y
   test('By default, the `aria-owns` attribute of the trigger contains the id of the content', async function (assert) {
     assert.expect(1);


### PR DESCRIPTION
Sometime between v1.x and v3.x a regression was introduced when specifying a dropdown that has no trigger, like in the cookbook entry. (https://ember-basic-dropdown.com/cookbook/no-trigger)

I don't know how to fix the bug, but this test fails and demonstrates it reproducibly.

I think the root cause is that `BasicDropdownContent` never gets `triggerElement` set if you don't use `<dd.Trigger>`. So when you click again on your custom trigger, `handleRootMouseDown` fires and can't disqualify the click. So it calls the `close` action. Then, your custom trigger also handles the click and calls `toggle`. It closes and re-opens in one click!

In the previous version we used, which is the ancient v1.x, `BasicDropdownContent` would do the `data-ebd-id` lookup when `open` was called. This allowed it to have `triggerElement` set even if `<dd.trigger>` isn't used.
See:
https://github.com/cibernox/ember-basic-dropdown/blob/v1.1.3/addon/components/basic-dropdown/content.js#L145-L147