### PR TITLE
Fix for https://github.com/cibernox/ember-basic-dropdown/issues/615

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -125,6 +125,7 @@ export default class BasicDropdownContent extends Component<Args> {
   @action
   animateOut(dropdownElement: Element): void {
     if (!this.animationEnabled) return;
+    this.animationClass = this.transitioningInClass;
     let parentElement = dropdownElement.parentElement;
     if (parentElement === null) return;
     if (this.args.renderInPlace) {
@@ -136,7 +137,6 @@ export default class BasicDropdownContent extends Component<Args> {
     clone.classList.remove(...this.transitioningInClass.split(' '));
     clone.classList.add(...this.transitioningOutClass.split(' '));
     parentElement.appendChild(clone);
-    this.animationClass = this.transitionedInClass;
     waitForAnimations(clone, function() {
       (parentElement as HTMLElement).removeChild(clone);
     });

--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -126,11 +126,7 @@ export default class BasicDropdownContent extends Component<Args> {
   animateOut(dropdownElement: Element): void {
     if (!this.animationEnabled) return;
     this.animationClass = this.transitioningInClass;
-    let parentElement = dropdownElement.parentElement;
-    if (parentElement === null) return;
-    if (this.args.renderInPlace) {
-      parentElement = parentElement.parentElement
-    }
+    let parentElement = this.destinationElement;
     if (parentElement === null) return;
     let clone = dropdownElement.cloneNode(true) as Element;
     clone.id = `${clone.id}--clone`;


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-basic-dropdown/issues/615 🤞 

I noticed that as of https://github.com/cibernox/ember-basic-dropdown/commit/1819c011578dbd23f969b08501ca1685d01dcdf8#diff-73297f8c71645544a2a6826e5c3146aff7cb2333d9c17fe968258e5f14dc4a79R164 the animationClass was set to `transitionedInClass` when animating out. I set this back to the original value, and also reordered the calls to preemptively set the state on transitioning out, regardless if the parent element exists. I _think_ this is correct because no matter what the reason (barring animation disabled), on a transition out we want to be able to render with the correct value when the drop down enters the dom again.