### PR TITLE
Fixes usage of aria-owns/controls in trigger

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -389,7 +389,7 @@ function dropdownIsValidParent(el: Element, dropdownId: string): boolean {
   } else {
     let closestAttrs = closestDropdown.attributes as unknown as any;
     let trigger = document.querySelector(
-      `[aria-owns=${closestAttrs.id.value}]`
+      `[aria-controls=${closestAttrs.id.value}]`
     );
     if (trigger === null) return false;
     let parentDropdown = closestContent(trigger);

--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -155,6 +155,13 @@ export default class BasicDropdown extends Component<Args> {
     }
     this.isOpen = true;
     this.args.registerAPI && this.args.registerAPI(this.publicAPI);
+    let trigger = document.querySelector(
+      `[data-ebd-id=${this.publicAPI.uniqueId}-trigger]`
+    ) as HTMLElement;
+    if (trigger) {
+      let parent = trigger.parentElement;
+      if (parent) { parent.setAttribute("aria-owns", this._dropdownId); }
+    }
   }
 
   @action
@@ -176,13 +183,18 @@ export default class BasicDropdown extends Component<Args> {
     this.previousVerticalPosition = this.previousHorizontalPosition = undefined;
     this.isOpen = false;
     this.args.registerAPI && this.args.registerAPI(this.publicAPI);
-    if (skipFocus) {
-      return;
-    }
     let trigger = document.querySelector(
       `[data-ebd-id=${this.publicAPI.uniqueId}-trigger]`
     ) as HTMLElement;
-    if (trigger && trigger.tabIndex > -1) {
+    if (!trigger) {
+      return;
+    }
+    let parent = trigger.parentElement;
+    if (parent) { parent.removeAttribute("aria-owns"); }
+    if (skipFocus) {
+      return;
+    }
+    if (trigger.tabIndex > -1) {
       trigger.focus();
     }
   }

--- a/addon/templates/components/basic-dropdown-trigger.hbs
+++ b/addon/templates/components/basic-dropdown-trigger.hbs
@@ -9,6 +9,7 @@
     tabindex={{unless @dropdown.disabled '0'}}
     data-ebd-id='{{@dropdown.uniqueId}}-trigger'
     aria-owns='ember-basic-dropdown-content-{{@dropdown.uniqueId}}'
+    aria-controls='ember-basic-dropdown-content-{{@dropdown.uniqueId}}'
     aria-expanded='{{@dropdown.isOpen}}'
     aria-disabled={{if @dropdown.disabled 'true'}}
     ...attributes

--- a/tests/integration/components/basic-dropdown-test.js
+++ b/tests/integration/components/basic-dropdown-test.js
@@ -618,7 +618,7 @@ module('Integration | Component | basic-dropdown', function (hooks) {
   });
 
   // A11y
-  test('By default, the `aria-owns` attribute of the trigger contains the id of the content', async function (assert) {
+  test('By default, the `aria-controls` attribute of the trigger contains the id of the content', async function (assert) {
     assert.expect(1);
 
     await render(hbs`
@@ -632,9 +632,35 @@ module('Integration | Component | basic-dropdown', function (hooks) {
     assert
       .dom('.ember-basic-dropdown-trigger')
       .hasAttribute(
-        'aria-owns',
+        'aria-controls',
         content.id,
         'The trigger controls the content'
+      );
+  });
+
+  test('When opened, the `aria-owns` attribute of the trigger parent contains the id of the content', async function (assert) {
+    assert.expect(2);
+    await render(hbs`
+      <BasicDropdown @renderInPlace={{true}} as |dropdown|>
+        <dropdown.Trigger>Click me</dropdown.Trigger>
+        <dropdown.Content><div id="dropdown-is-opened"></div></dropdown.Content>
+      </BasicDropdown>
+    `);
+    let trigger = this.element.querySelector('.ember-basic-dropdown-trigger');
+    assert
+      .dom(trigger.parentNode)
+      .doesNotHaveAttribute(
+        'aria-owns',
+        'Closed dropdown parent does not have aria-owns'
+      );
+    await click('.ember-basic-dropdown-trigger');
+    let content = this.element.querySelector('.ember-basic-dropdown-content');
+    assert
+      .dom(trigger.parentNode)
+      .hasAttribute(
+        'aria-owns',
+        content.id,
+        'The trigger parent owns the content'
       );
   });
 

--- a/tests/integration/components/trigger-test.js
+++ b/tests/integration/components/trigger-test.js
@@ -148,7 +148,7 @@ module('Integration | Component | basic-dropdown-trigger', function (hooks) {
       .hasAttribute('aria-expanded', 'true', 'the aria-expanded is true');
   });
 
-  test('If it has an `aria-owns="foo123"` attribute pointing to the id of the content', async function (assert) {
+  test('If it has an `aria-controls="foo123"` attribute pointing to the id of the content', async function (assert) {
     assert.expect(1);
     this.dropdown = { uniqueId: 123 };
     await render(hbs`
@@ -156,7 +156,7 @@ module('Integration | Component | basic-dropdown-trigger', function (hooks) {
     `);
     assert
       .dom('.ember-basic-dropdown-trigger')
-      .hasAttribute('aria-owns', 'ember-basic-dropdown-content-123');
+      .hasAttribute('aria-controls', 'ember-basic-dropdown-content-123');
   });
 
   test('If it receives `@htmlTag`, the trigger uses that tag name', async function (assert) {


### PR DESCRIPTION
Closes https://github.com/cibernox/ember-basic-dropdown/issues/557.

This mostly just fixes the merge conflicts present in https://github.com/cibernox/ember-basic-dropdown/pull/558.
To re-iterate, this commit uses `aria-controls` instead of `aria-owns` to build the relationship between the trigger and its content. In addition, the `aria-owns` property is migrated to the trigger's parent.

This fixes an issue I ran into using Apple's VoiceOver software, in which I couldn't use the movement commands (VO+right-arrow) to navigate into dropdown menus created with ember-basic-dropdown.