### PR TITLE
Avoid deprecation for `import { assign } from '@ember/polyfills'`

### DIFF
--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -295,8 +295,7 @@ export default class BasicDropdown extends Component<Args> {
       }
     }
     for (let prop in positions.style) {
-      // Array.includes is not available for IE11
-      if (IGNORED_STYLES.indexOf(prop) === -1) {
+      if (!IGNORED_STYLES.includes(prop)) {
         changes.otherStyles;
         changes.otherStyles[prop] = positions.style[prop];
       }

--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -3,7 +3,6 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { getOwner } from '@ember/application';
-import { assign } from '@ember/polyfills';
 import calculatePosition, {
   CalculatePosition,
   CalculatePositionResult,
@@ -257,7 +256,7 @@ export default class BasicDropdown extends Component<Args> {
     let changes: RepositionChanges = {
       hPosition: positions.horizontalPosition,
       vPosition: positions.verticalPosition,
-      otherStyles: assign({}, this.otherStyles),
+      otherStyles: Object.assign({}, this.otherStyles),
     };
 
     if (positions.style) {


### PR DESCRIPTION
Use `Object.assign` instead of `Ember.assign`, as that is deprecated here: https://github.com/emberjs/rfcs/blob/master/text/0750-deprecate-ember-assign.md

This basically means that support for IE11 is dropped. I guess you could still run this with IE11 by providing a global polyfill yourself for `Object.assign`.