### PR TITLE
Fix misleading documentation for destination

### DIFF
--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -43,7 +43,7 @@
     <tr>
       <td>destination</td>
       <td>String</td>
-      <td>The selector of a DOM element where the dropdown will be rendered
+      <td>The id of a DOM element where the dropdown will be rendered
         using
         <code>#-in-element</code></td>
     </tr>


### PR DESCRIPTION
The destination option doesn't accept a selector, it only accepts an id.

There is [an open PR](https://github.com/cibernox/ember-basic-dropdown/issues/406) about changing that, but it never landed.