### PR TITLE
Update CI Status Badge to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember-basic-dropdown
 
-[![Build Status](https://travis-ci.org/cibernox/ember-basic-dropdown.svg?branch=master)](https://travis-ci.org/cibernox/ember-basic-dropdown)
+[![Build Status](https://github.com/cibernox/ember-basic-dropdown/actions/workflows/ci.yml/badge.svg?branch=master)](https://travis-ci.org/cibernox/ember-basic-dropdown)
 
 This is a very minimal dropdown. That means that it is agnostic about what it is going to contain.
 


### PR DESCRIPTION
This PR updates the CI badge Status that was pointing to the latest failed CI build on Travis. It is now pointing to the latest CI GitHub Actions workflow status.

![image](https://user-images.githubusercontent.com/176766/152760975-2b4203b5-48b5-4d86-a360-b5c6c1565091.png)
 