### PR TITLE
Fix docs mobile layout

### DIFF
--- a/tests/dummy/app/controllers/public-pages/docs.js
+++ b/tests/dummy/app/controllers/public-pages/docs.js
@@ -4,6 +4,7 @@ import Controller from '@ember/controller';
 
 const groupedSections = [
   {
+    id: 'getting-started',
     groupName: 'Getting started',
     options: [
       { route: 'public-pages.docs.index', text: 'Overview' },
@@ -15,6 +16,7 @@ const groupedSections = [
     ],
   },
   {
+    id: 'basic-customization',
     groupName: 'Basic customization',
     options: [
       { route: 'public-pages.docs.position', text: 'Position' },
@@ -24,12 +26,15 @@ const groupedSections = [
     ],
   },
   {
+    id: 'advanced-customization',
     groupName: 'Advanced customization',
     options: [
       { route: 'public-pages.docs.custom-position', text: 'Custom position' },
+      { route: 'public-pages.docs.animations', text: 'Animations' },
     ],
   },
   {
+    id: 'other',
     groupName: 'Other',
     options: [
       { route: 'public-pages.docs.test-helpers', text: 'Test helpers' },

--- a/tests/dummy/app/styles/_utilities.scss
+++ b/tests/dummy/app/styles/_utilities.scss
@@ -20,8 +20,8 @@
   display: block;
 }
 %wrapper {
-  max-width: 1024px; // not 960px because it's 2015
-  width: 1024px;
+  max-width: 1024px;
+  width: 100%;
   padding-left: $wrapper-padding;
   padding-right: $wrapper-padding;
   margin-left: auto;

--- a/tests/dummy/app/styles/components/main-header.scss
+++ b/tests/dummy/app/styles/components/main-header.scss
@@ -83,6 +83,7 @@
   .main-header-nav-links {
     justify-content: space-between;
     background-color: rgba(black, 0.2);
+    overflow-x: auto;
   }
 }
 @media only screen and (min-width: $small-breakpoint) {

--- a/tests/dummy/app/templates/public-pages/docs.hbs
+++ b/tests/dummy/app/templates/public-pages/docs.hbs
@@ -1,69 +1,31 @@
-<section class='docs'>
-  <nav class='side-nav'>
-    <header class='side-nav-header' id="getting-started">Getting started</header>
-    <LinkTo
-      @route='public-pages.docs.index'
-      class='side-nav-link'
-    >Overview</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.installation'
-      class='side-nav-link'
-    >Installation</LinkTo>
-    <LinkTo @route='public-pages.docs.how-to-use-it' class='side-nav-link'>How
-      to use it</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.dropdown-events'
-      class='side-nav-link'
-    >Dropdown events</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.trigger-events'
-      class='side-nav-link'
-    >Trigger events</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.content-events'
-      class='side-nav-link'
-    >Content events</LinkTo>
-    <header class='side-nav-header' id="basic-customization">Basic customization</header>
-    <LinkTo
-      @route='public-pages.docs.position'
-      class='side-nav-link'
-    >Position</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.disabled'
-      class='side-nav-link'
-    >Disabled</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.overlays'
-      class='side-nav-link'
-    >Overlays</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.styles'
-      class='side-nav-link'
-    >Styles</LinkTo>
-    <header class='side-nav-header' id="advanced-customization">Advanced customization</header>
-    <LinkTo
-      @route='public-pages.docs.custom-position'
-      class='side-nav-link'
-    >Custom position</LinkTo>
-    <LinkTo
-      @route='public-pages.docs.animations'
-      class='side-nav-link'
-    >Animations</LinkTo>
-    <header class='side-nav-header'>Other</header>
-    <LinkTo @route='public-pages.docs.test-helpers' class='side-nav-link'>Test
-      helpers</LinkTo>
-    <LinkTo @route='public-pages.docs.api-reference' class='side-nav-link'>API
-      reference</LinkTo>
+<section class="docs">
+  <nav class="side-nav">
+    {{#each this.groupedSections key='id' as |group|}}
+      <header class="side-nav-header" id={{group.id}}>
+        {{group.groupName}}
+      </header>
+      {{#each group.options key='route' as |option|}}
+        <LinkTo
+          @route={{option.route}}
+          @current-when={{option.route}}
+          class="side-nav-link"
+        >
+          {{option.text}}
+        </LinkTo>
+      {{/each}}
+    {{/each}}
   </nav>
-  <section class='doc-page'>
-    <select {{on 'change' this.visit}} class='section-selector'>
-      {{#each this.groupedSections as |group|}}
+  <section class="doc-page">
+    <select class="section-selector" {{on 'change' this.visit}}>
+      {{#each this.groupedSections key='id' as |group|}}
         <optgroup label={{group.groupName}}>
-          {{#each group.options as |section|}}
+          {{#each group.options key='route' as |section|}}
             <option
               value={{section.route}}
               selected={{eq section.route this.currentSection.route}}
-            >{{section.text}}</option>
+            >
+              {{section.text}}
+            </option>
           {{/each}}
         </optgroup>
       {{/each}}


### PR DESCRIPTION
This PR fixes the docs styles on mobile layout. 

1. The width of the content wrapper divs was fixed to 1024px with a max-width of 1024px. So I switched the width to be 100%. 

https://user-images.githubusercontent.com/176766/152803909-444293cc-5bb3-4e93-83a5-3e93ef5241f6.mov


2. I also added an `overflow-x` to the header links on mobile in case it overflows
3. In the `docs` page, I made the `groupedSections` the source of truth for both navigations (main nav and the native select on mobile)
4. It was missing the animations page on mobile  