### PR TITLE
Only set animationClass on dropdown-content when animations are enabled

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -54,7 +54,7 @@ export default class BasicDropdownContent extends Component<Args> {
   private handleRootMouseDown?: RootMouseDownHandler;
   private scrollableAncestors: Element[] = [];
   private mutationObserver?: MutationObserver;
-  @tracked animationClass = this.transitioningInClass;
+  @tracked animationClass = this.animationEnabled ? this.transitioningInClass : '';
 
   get destinationElement(): Element | null {
     return document.getElementById(this.args.destination);


### PR DESCRIPTION
This fixes an issue where the dropdown content would be invisible in tests due to the transitioning in class always being set. Broke visual regression testing etc.