### PR TITLE
Type error fix:  `ember-basic-dropdown` does not exist on type  {environment: string; ...}

### DIFF
--- a/addon/components/basic-dropdown.ts
+++ b/addon/components/basic-dropdown.ts
@@ -334,8 +334,10 @@ export default class BasicDropdown extends Component<Args> {
       return '';
     }
 
-    return ((config['ember-basic-dropdown'] &&
-      config['ember-basic-dropdown'].destination) ||
+    const _config = config as unknown as any;
+
+    return ((_config['ember-basic-dropdown'] &&
+    _config['ember-basic-dropdown'].destination) ||
       'ember-basic-dropdown-wormhole') as string;
   }
 }


### PR DESCRIPTION
The 'ember-basic-dropdown' config key is technically defined correctly as:
```
 'ember-basic-dropdown': {
    destination: string
  } | undefined
```

Which means that it might be `undefined` and the client app might not have it set. So far so good.

The problem with the type occurs when the client app does not have it defined in  its own `config/environment.d.ts` .

During build the config type is set to the clients app type that  when `ember-basic-dropdown` field type is not set, we get this type error:

```
Property 'ember-basic-dropdown' does not exist on type '{ environment: string; modulePrefix: string; podModulePrefix: string; locationType: string; rootURL: string;}; ...}
```


**The fix:** 
- Added type assertion to config in destination element.

When accessing `ember-basic-dropdown` field on `config` we should treat it as any



