### PR TITLE
refactor: fix deprecations from trigger modifier

### DIFF
--- a/addon/modifiers/basic-dropdown-trigger.ts
+++ b/addon/modifiers/basic-dropdown-trigger.ts
@@ -36,7 +36,7 @@ export default class DropdownTriggerModifier extends Modifier<Signature> {
   }
 
   modify(element: HTMLElement, positional: PositionalArgs<Signature>, named: NamedArgs<Signature>): void {
-    assert('must be provided dropdown element', named.dropdown)
+    assert('must be provided dropdown object', named.dropdown)
     this.dropdown = named.dropdown
     this.desiredEventType = named.eventType ?? 'click'
     this.stopPropagation = named.stopPropagation


### PR DESCRIPTION
Follow up to https://github.com/cibernox/ember-basic-dropdown/pull/626

Fixes some deprecations - was still using the deprecated ember-modifier API in places. Specifically in regards to using `this.args` and `this.isDestroyed`