### PR TITLE
Allow ember-get-config v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-typescript": "^4.2.1",
     "ember-element-helper": "^0.6.0",
-    "ember-get-config": "^1.0.2",
+    "ember-get-config": "^1.0.2 || ^2.0.0",
     "ember-maybe-in-element": "^2.0.3",
     "ember-modifier": "^3.2.7",
     "ember-style-modifier": "^0.8.0",


### PR DESCRIPTION
This allow ember-get-config dependency to be v2.0.0
This addon was forcing the v1 on my app which caused trouble building, started happening yesterday don't know why, with v2 everything works.