### PR TITLE
Update `ember-get-config` to v2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ember-cli-htmlbars": "^6.0.1",
         "ember-cli-typescript": "^4.2.1",
         "ember-element-helper": "^0.6.0",
-        "ember-get-config": "^1.0.2 || ^2.0.0",
+        "ember-get-config": "^2.1.1",
         "ember-maybe-in-element": "^2.0.3",
         "ember-modifier": "^3.2.7",
         "ember-style-modifier": "^0.8.0",
@@ -11742,9 +11742,9 @@
       }
     },
     "node_modules/ember-get-config": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-1.0.4.tgz",
-      "integrity": "sha512-WOnf1E0ceRHWy7apnmUFbKcJm2c3KOg4rNNUKNtBFCFp770tOTwv5LAYcqV4+HootPCsQYL7oFUd/0JLiZpMeg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-2.1.1.tgz",
+      "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
       "dependencies": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"
@@ -36836,9 +36836,9 @@
       "dev": true
     },
     "ember-get-config": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-1.0.4.tgz",
-      "integrity": "sha512-WOnf1E0ceRHWy7apnmUFbKcJm2c3KOg4rNNUKNtBFCFp770tOTwv5LAYcqV4+HootPCsQYL7oFUd/0JLiZpMeg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ember-get-config/-/ember-get-config-2.1.1.tgz",
+      "integrity": "sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==",
       "requires": {
         "@embroider/macros": "^0.50.0 || ^1.0.0",
         "ember-cli-babel": "^7.26.6"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-typescript": "^4.2.1",
     "ember-element-helper": "^0.6.0",
-    "ember-get-config": "^1.0.2 || ^2.0.0",
+    "ember-get-config": "^2.1.1",
     "ember-maybe-in-element": "^2.0.3",
     "ember-modifier": "^3.2.7",
     "ember-style-modifier": "^0.8.0",


### PR DESCRIPTION
Versions below v2.1 should be avoided, see:
- https://github.com/mansona/ember-get-config/releases/tag/v2.1.0
- https://github.com/mansona/ember-get-config/pull/45