### PR TITLE
find dropdown root using trigger.parentElement

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -150,12 +150,10 @@ export default class BasicDropdownContent extends Component<Args> {
   animateOut(dropdownElement: Element): void {
     if (!this.animationEnabled) return;
     let parentElement =
-      dropdownElement.parentElement ?? this.destinationElement;
-    if (parentElement === null) return;
-    if (this.args.renderInPlace) {
-      parentElement = parentElement.parentElement;
-    }
-    if (parentElement === null) return;
+      this.args.renderInPlace ? document.querySelector(
+        `[aria-controls="ember-basic-dropdown-content-${this.args.dropdown.uniqueId}"]`
+      )?.parentElement : this.destinationElement;
+    if (!parentElement) return;
     let clone = dropdownElement.cloneNode(true) as Element;
     clone.id = `${clone.id}--clone`;
     clone.classList.remove(...this.transitioningInClass.split(' '));


### PR DESCRIPTION
This should fix #583

`will-destroy` can run at the [same tick as dropdown content removal](https://github.com/pzuraq/emberjs-rfcs/blob/render-element-modifiers/text/0000-render-element-modifiers.md#will-destroy). If it is indeed removed from the DOM, we would not be able to find the container by starting from the dropdown content, so this PR uses the trigger to find the container instead. 

It seems difficult to test this - I've tried using paused animations (but this doesn't play nice with `waitForAnimations` which only waits for a running animation), however I'd be happy to implement suggestions.