### PR TITLE
Allow passing @animationEnabled argument to BasicDropdownContent

### DIFF
--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -13,6 +13,7 @@ import { Dropdown } from './basic-dropdown';
 import { isTesting } from '@embroider/macros';
 
 interface Args {
+  animationEnabled?: boolean;
   transitioningInClass?: string;
   transitionedInClass?: string;
   transitioningOutClass?: string;
@@ -61,7 +62,9 @@ export default class BasicDropdownContent extends Component<Args> {
   }
 
   get animationEnabled(): boolean {
-    return !isTesting();
+    const { animationEnabled: animationEnabledArg = true } = this.args;
+
+    return animationEnabledArg && !isTesting();
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/cibernox/ember-basic-dropdown/issues/550

This argument is documented in both ember-basic-dropdown and ember-power-select, but never actually used or passed along. I'll also create a PR in ember-power-select to pass the argument along.