### PR TITLE
Fixed support for Ember 5.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ module.exports = {
     app.__emberBasicDropdownIncludedInvoked = true;
     this._super.included.apply(this, arguments);
 
-    let hasSass = !!app.registry.availablePlugins['ember-cli-sass'];
-    let hasLess = !!app.registry.availablePlugins['ember-cli-less'];
+    const addons = app.project?.addonPackages || app.registry?.availablePlugins;
+    const hasSass = !!addons['ember-cli-sass'];
+    const hasLess = !!addons['ember-cli-less'];
 
     // Don't include the precompiled css file if the user uses a supported CSS preprocessor
     if (!hasSass && !hasLess) {


### PR DESCRIPTION
Based on suggestion by @fastindian84, this fixes the following error with Ember 5.0.0:

```
Cannot read properties of undefined (reading 'ember-cli-sass')
```

Fixes #706