### PR TITLE
Update ember-element-helper to v0.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
+          - ember-5.0
           - ember-release
           - ember-beta
           - ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -51,6 +51,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-5.0',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.0.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ember-cli-babel": "^7.26.11",
         "ember-cli-htmlbars": "^6.2.0",
         "ember-cli-typescript": "^5.2.1",
-        "ember-element-helper": "^0.6.1",
+        "ember-element-helper": "^0.7.1",
         "ember-get-config": "^2.1.1",
         "ember-maybe-in-element": "^2.1.0",
         "ember-modifier": "^3.2.7 || ^4.0.0",
@@ -12156,19 +12156,48 @@
       }
     },
     "node_modules/ember-element-helper": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.6.1.tgz",
-      "integrity": "sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.7.1.tgz",
+      "integrity": "sha512-vpD/ZVXU3MCbW/oKw/Wg2z3H/KHYIiO9ej28By1POnN+HVw4sHHJVStxgVoztiK1P43JoGRpyoJvMB986xrGSw==",
       "dependencies": {
-        "@embroider/util": "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1"
+        "@embroider/addon-shim": "1.8.3",
+        "@embroider/util": "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0"
+      },
+      "engines": {
+        "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.8 || ^4.0.0 || >= 5.0.0"
+      }
+    },
+    "node_modules/ember-element-helper/node_modules/@embroider/addon-shim": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.3.tgz",
+      "integrity": "sha512-7pyHwzT6ESXc3nZsB8rfnirLkUhQWdvj6CkYH+0MUPN74mX4rslf7pnBqZE/KZkW3uBIaBYvU8fxi0hcKC/Paw==",
+      "dependencies": {
+        "@embroider/shared-internals": "^1.8.3",
+        "semver": "^7.3.5"
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-element-helper/node_modules/@embroider/shared-internals": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.3.tgz",
+      "integrity": "sha512-N5Gho6Qk8z5u+mxLCcMYAoQMbN4MmH+z2jXwQHVs859bxuZTxwF6kKtsybDAASCtd2YGxEmzcc1Ja/wM28824w==",
+      "dependencies": {
+        "babel-import-util": "^1.1.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
       },
-      "peerDependencies": {
-        "ember-source": "^3.8 || 4"
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-get-config": {
@@ -36846,13 +36875,38 @@
       }
     },
     "ember-element-helper": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.6.1.tgz",
-      "integrity": "sha512-YiOdAMlzYul4ulkIoNp8z7iHDfbT1fbut/9xGFRfxDwU/FmF8HtAUB2f1veu/w50HTeZNopa1OV2PCloZ76XlQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ember-element-helper/-/ember-element-helper-0.7.1.tgz",
+      "integrity": "sha512-vpD/ZVXU3MCbW/oKw/Wg2z3H/KHYIiO9ej28By1POnN+HVw4sHHJVStxgVoztiK1P43JoGRpyoJvMB986xrGSw==",
       "requires": {
-        "@embroider/util": "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1"
+        "@embroider/addon-shim": "1.8.3",
+        "@embroider/util": "^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0"
+      },
+      "dependencies": {
+        "@embroider/addon-shim": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.3.tgz",
+          "integrity": "sha512-7pyHwzT6ESXc3nZsB8rfnirLkUhQWdvj6CkYH+0MUPN74mX4rslf7pnBqZE/KZkW3uBIaBYvU8fxi0hcKC/Paw==",
+          "requires": {
+            "@embroider/shared-internals": "^1.8.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@embroider/shared-internals": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.3.tgz",
+          "integrity": "sha512-N5Gho6Qk8z5u+mxLCcMYAoQMbN4MmH+z2jXwQHVs859bxuZTxwF6kKtsybDAASCtd2YGxEmzcc1Ja/wM28824w==",
+          "requires": {
+            "babel-import-util": "^1.1.0",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          }
+        }
       }
     },
     "ember-get-config": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-cli-typescript": "^5.2.1",
-    "ember-element-helper": "^0.6.1",
+    "ember-element-helper": "^0.7.1",
     "ember-get-config": "^2.1.1",
     "ember-maybe-in-element": "^2.1.0",
     "ember-modifier": "^3.2.7 || ^4.0.0",


### PR DESCRIPTION
There was released a new version of [ember-element-helper](https://github.com/tildeio/ember-element-helper/blob/v0.7.1/ember-element-helper/CHANGELOG.md). No braking changes, only added support for `ember-source` v5.