### PR TITLE
Drop `@ember/render-modifiers`

### DIFF
--- a/addon/components/basic-dropdown-content.hbs
+++ b/addon/components/basic-dropdown-content.hbs
@@ -25,9 +25,8 @@
           {{did-insert this.setup}}
           {{did-insert @dropdown.actions.reposition}}
           {{did-insert this.setupMutationObserver}}
-          {{did-insert this.animateIn}}
+          {{this.animateInAndOut}}
           {{will-destroy this.teardownMutationObserver}}
-          {{will-destroy this.animateOut}}
           {{will-destroy this.teardown}}
           {{on 'focusin' (fn (or @onFocusIn this.noop) @dropdown)}}
           {{on 'focusout' (fn (or @onFocusOut this.noop) @dropdown)}}

--- a/addon/components/basic-dropdown-content.hbs
+++ b/addon/components/basic-dropdown-content.hbs
@@ -23,7 +23,7 @@
             this.positionStyles
           }}
           {{this.respondToEvents}}
-          {{did-insert @dropdown.actions.reposition}}
+          {{this.initiallyReposition}}
           {{this.observeMutations}}
           {{this.animateInAndOut}}
           {{on 'focusin' (fn (or @onFocusIn this.noop) @dropdown)}}

--- a/addon/components/basic-dropdown-content.hbs
+++ b/addon/components/basic-dropdown-content.hbs
@@ -22,11 +22,10 @@
             @otherStyles
             this.positionStyles
           }}
-          {{did-insert this.setup}}
+          {{this.respondToEvents}}
           {{did-insert @dropdown.actions.reposition}}
           {{this.observeMutations}}
           {{this.animateInAndOut}}
-          {{will-destroy this.teardown}}
           {{on 'focusin' (fn (or @onFocusIn this.noop) @dropdown)}}
           {{on 'focusout' (fn (or @onFocusOut this.noop) @dropdown)}}
           {{on 'mouseenter' (fn (or @onMouseEnter this.noop) @dropdown)}}

--- a/addon/components/basic-dropdown-content.hbs
+++ b/addon/components/basic-dropdown-content.hbs
@@ -24,9 +24,8 @@
           }}
           {{did-insert this.setup}}
           {{did-insert @dropdown.actions.reposition}}
-          {{did-insert this.setupMutationObserver}}
+          {{this.observeMutations}}
           {{this.animateInAndOut}}
-          {{will-destroy this.teardownMutationObserver}}
           {{will-destroy this.teardown}}
           {{on 'focusin' (fn (or @onFocusIn this.noop) @dropdown)}}
           {{on 'focusout' (fn (or @onFocusOut this.noop) @dropdown)}}

--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -188,8 +188,7 @@ export default class BasicDropdownContent extends Component<Args> {
     };
   });
 
-  @action
-  setupMutationObserver(dropdownElement: Element): void {
+  observeMutations = modifier((dropdownElement: Element): () => void => {
     this.mutationObserver = new MutationObserver((mutations) => {
       let shouldReposition = mutations.some(
         (record: MutationRecord) =>
@@ -212,15 +211,13 @@ export default class BasicDropdownContent extends Component<Args> {
       childList: true,
       subtree: true,
     });
-  }
-
-  @action
-  teardownMutationObserver(): void {
-    if (this.mutationObserver !== undefined) {
-      this.mutationObserver.disconnect();
-      this.mutationObserver = undefined;
+    return () => {
+      if (this.mutationObserver !== undefined) {
+        this.mutationObserver.disconnect();
+        this.mutationObserver = undefined;
+      }
     }
-  }
+  });
 
   @action
   touchStartHandler(): void {

--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -159,6 +159,13 @@ export default class BasicDropdownContent extends Component<Args> {
     }
   });
 
+  initiallyReposition = modifier(() => {
+    // Escape autotracking frame and avoid backtracking re-render
+    Promise.resolve().then(() => {
+      this.args.dropdown.actions.reposition()
+    });
+  });
+
   animateInAndOut = modifier((dropdownElement: Element): () => void => {
     if (!this.animationEnabled) return () => {};
     waitForAnimations(dropdownElement, () => {

--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -98,8 +98,7 @@ export default class BasicDropdownContent extends Component<Args> {
    */
   noop(): void {}
 
-  @action
-  setup(dropdownElement: Element): void {
+  respondToEvents = modifier((dropdownElement: Element): () => void => {
     let triggerElement = document.querySelector(
       `[data-ebd-id=${this.args.dropdown.uniqueId}-trigger]`
     );
@@ -138,29 +137,27 @@ export default class BasicDropdownContent extends Component<Args> {
       this.scrollableAncestors = getScrollableAncestors(triggerElement);
     }
     this.addScrollHandling(dropdownElement);
-  }
+    return () => {
+      this.removeGlobalEvents();
+      this.removeScrollHandling();
+      this.scrollableAncestors = [];
 
-  @action
-  teardown(): void {
-    this.removeGlobalEvents();
-    this.removeScrollHandling();
-    this.scrollableAncestors = [];
-
-    document.removeEventListener(
-      this.args.rootEventType,
-      this.handleRootMouseDown as RootMouseDownHandler,
-      true
-    );
-
-    if (this.isTouchDevice) {
-      document.removeEventListener('touchstart', this.touchStartHandler, true);
       document.removeEventListener(
-        'touchend',
+        this.args.rootEventType,
         this.handleRootMouseDown as RootMouseDownHandler,
         true
       );
+
+      if (this.isTouchDevice) {
+        document.removeEventListener('touchstart', this.touchStartHandler, true);
+        document.removeEventListener(
+          'touchend',
+          this.handleRootMouseDown as RootMouseDownHandler,
+          true
+        );
+      }
     }
-  }
+  });
 
   animateInAndOut = modifier((dropdownElement: Element): () => void => {
     if (!this.animationEnabled) return () => {};

--- a/addon/components/basic-dropdown-content.ts
+++ b/addon/components/basic-dropdown-content.ts
@@ -157,14 +157,16 @@ export default class BasicDropdownContent extends Component<Args> {
         );
       }
     }
-  });
+  // @ts-ignore
+  }, { eager: false });
 
   initiallyReposition = modifier(() => {
     // Escape autotracking frame and avoid backtracking re-render
     Promise.resolve().then(() => {
       this.args.dropdown.actions.reposition()
     });
-  });
+  // @ts-ignore
+  }, { eager: false });
 
   animateInAndOut = modifier((dropdownElement: Element): () => void => {
     if (!this.animationEnabled) return () => {};
@@ -190,7 +192,8 @@ export default class BasicDropdownContent extends Component<Args> {
         (parentElement as HTMLElement).removeChild(clone);
       });
     };
-  });
+  // @ts-ignore
+  }, { eager: false });
 
   observeMutations = modifier((dropdownElement: Element): () => void => {
     this.mutationObserver = new MutationObserver((mutations) => {
@@ -221,7 +224,8 @@ export default class BasicDropdownContent extends Component<Args> {
         this.mutationObserver = undefined;
       }
     }
-  });
+  // @ts-ignore
+  }, { eager: false });
 
   @action
   touchStartHandler(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.2.2",
       "license": "MIT",
       "dependencies": {
-        "@ember/render-modifiers": "^2.0.5",
         "@embroider/macros": "^1.12.0",
         "@embroider/util": "^1.11.0",
         "@glimmer/component": "^1.1.2",
@@ -2000,6 +1999,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-2.1.0.tgz",
       "integrity": "sha512-LruhfoDv2itpk0fA0IC76Sxjcnq/7BC6txpQo40hOko8Dn6OxwQfxkPIbZGV0Cz7df+iX+VJrcYzNIvlc3w2EQ==",
+      "dev": true,
       "dependencies": {
         "@embroider/macros": "^1.0.0",
         "ember-cli-babel": "^7.26.11",
@@ -12480,6 +12480,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz",
       "integrity": "sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==",
+      "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.10.0",
         "ember-cli-version-checker": "^2.1.2",
@@ -12493,6 +12494,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
       "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+      "dev": true,
       "dependencies": {
         "resolve": "^1.3.3",
         "semver": "^5.3.0"
@@ -12505,6 +12507,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "@ember/render-modifiers": "^2.0.5",
     "@embroider/macros": "^1.12.0",
     "@embroider/util": "^1.11.0",
     "@glimmer/component": "^1.1.2",

--- a/tests/dummy/app/components/autofocus-input.js
+++ b/tests/dummy/app/components/autofocus-input.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
+import { modifier } from 'ember-modifier';
 
 export default class extends Component {
-  focusInput(input) {
+  focusInput = modifier((input) => {
     input.focus();
-  }
+  });
 }

--- a/tests/dummy/app/templates/components/autofocus-input.hbs
+++ b/tests/dummy/app/templates/components/autofocus-input.hbs
@@ -1,1 +1,1 @@
-<input type='text' {{did-insert this.focusInput}} ...attributes />
+<input type='text' {{this.focusInput}} ...attributes />


### PR DESCRIPTION
Replaces the no-longer-recommended [render lifecycle modifiers](https://github.com/emberjs/ember-render-modifiers) with local function modifiers.

`@ember/render-modifiers` were meant as a transitional tool from the pre-Octane era, and not long-term usage.

Modifier code is directly ported from the setup/teardown hooks with no changes except what I've pointed out in code comments.

Recommend reviewing commit-by-commit.