### PR TITLE
Remove `ember-cli-htmlbars` workaround in ember-try

### DIFF
--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -3,16 +3,6 @@
 const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
-const embroiderSafeScenario = embroiderSafe();
-embroiderSafeScenario.npm.dependencies = {
-  'ember-cli-htmlbars': '^5.3.2',
-};
-
-const embroiderOptimizedScenario = embroiderOptimized();
-embroiderOptimizedScenario.npm.dependencies = {
-  'ember-cli-htmlbars': '^5.3.2',
-};
-
 module.exports = async function () {
   return {
     scenarios: [
@@ -82,8 +72,8 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafeScenario,
-      embroiderOptimizedScenario,
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
   };
 };


### PR DESCRIPTION
While updateing ember-cli i have seen that we have added workaround for embroider-tests some months ago.

This should not anymore necessary as we have updated in the last time a lot of packages