### PR TITLE
Fix peerDependency of ember-source in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "node": "16.* || >= 18"
       },
       "peerDependencies": {
-        "ember-source": "^3.28.0"
+        "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postpublish": "ember ts:clean"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0"
+    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
   },
   "engines": {
     "node": "16.* || >= 18"


### PR DESCRIPTION
While ember-cli update to 4.12.2 (https://github.com/cibernox/ember-basic-dropdown/pull/716) there were added wrong `peerDependencies`