### PR TITLE
Allow only latest version in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.23.2",
-        "@embroider/macros": "^1.12.0",
-        "@embroider/util": "^1.11.0",
+        "@babel/core": "^7.23.3",
+        "@embroider/macros": "^1.13.3",
+        "@embroider/util": "^1.12.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "ember-auto-import": "^2.6.3",
@@ -22,9 +22,9 @@
         "ember-element-helper": "^0.8.5",
         "ember-get-config": "^2.1.1",
         "ember-maybe-in-element": "^2.1.0",
-        "ember-modifier": "^3.2.7 || ^4.0.0",
-        "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
-        "ember-truth-helpers": "^2.1.0 || ^3.0.0 || ^4.0.0"
+        "ember-modifier": "^4.1.0",
+        "ember-style-modifier": "^3.0.1",
+        "ember-truth-helpers": "^4.0.3"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -107,9 +107,9 @@
     "test": "tests"
   },
   "dependencies": {
-    "@babel/core": "^7.23.2",
-    "@embroider/macros": "^1.12.0",
-    "@embroider/util": "^1.11.0",
+    "@babel/core": "^7.23.3",
+    "@embroider/macros": "^1.13.3",
+    "@embroider/util": "^1.12.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "ember-auto-import": "^2.6.3",
@@ -119,9 +119,9 @@
     "ember-element-helper": "^0.8.5",
     "ember-get-config": "^2.1.1",
     "ember-maybe-in-element": "^2.1.0",
-    "ember-modifier": "^3.2.7 || ^4.0.0",
-    "ember-style-modifier": "^0.8.0 || ^1.0.0 || ^2.0.0 || ^3.0.0",
-    "ember-truth-helpers": "^2.1.0 || ^3.0.0 || ^4.0.0"
+    "ember-modifier": "^4.1.0",
+    "ember-style-modifier": "^3.0.1",
+    "ember-truth-helpers": "^4.0.3"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
As we have already braking changes (specially after we move this addon to v2), we should also drop old dependency versions.

This gives us the guarantee that consumer apps use also the latest versions of dependencies.