### PR TITLE
docs: Fix that code snippets were rendered as [object Object]

### DIFF
--- a/docs/app/templates/public-pages/docs/styles.hbs
+++ b/docs/app/templates/public-pages/docs/styles.hbs
@@ -18,7 +18,9 @@
   There is only four variables you can tweak (Sass syntax)
 </p>
 
-{{get-code-snippet "styles-1.scss"}}
+{{#let (get-code-snippet "styles-1.scss") as |snippet|}}
+  <CodeBlock @language="scss" @code={{snippet.source}} />
+{{/let}}
 
 <p>
   If by example you want to change the colour of the overlay to be blue, you
@@ -26,7 +28,9 @@
   <code>app.scss</code>/<code>app.less</code>.
 </p>
 
-{{get-code-snippet "styles-2.scss" }}
+{{#let (get-code-snippet "styles-2.scss") as |snippet|}}
+  <CodeBlock @language="scss" @code={{snippet.source}} />
+{{/let}}
 
 <p>
   In the next sections we'll give in more involved customizations.


### PR DESCRIPTION
Fixes:
<img width="1047" alt="Screenshot 2024-01-06 at 13 04 11" src="https://github.com/cibernox/ember-basic-dropdown/assets/4601554/a34c36fb-63bc-4572-987b-30522e280c63">
