### PR TITLE
Add option to use `ember-basic-dropdown.scss`

### DIFF
--- a/ember-basic-dropdown/_index.scss
+++ b/ember-basic-dropdown/_index.scss
@@ -1,2 +1,1 @@
-@import './scss/variables.scss';
-@import './scss/base.scss';
+@import './ember-basic-dropdown.scss';

--- a/ember-basic-dropdown/ember-basic-dropdown.scss
+++ b/ember-basic-dropdown/ember-basic-dropdown.scss
@@ -1,0 +1,2 @@
+@import './scss/variables.scss';
+@import './scss/base.scss';

--- a/ember-basic-dropdown/package.json
+++ b/ember-basic-dropdown/package.json
@@ -19,6 +19,7 @@
     },
     "./addon-main.js": "./addon-main.cjs",
     "./ember-basic-dropdown.less": "./ember-basic-dropdown.less",
+    "./ember-basic-dropdown.scss": "./ember-basic-dropdown.scss",
     "./_index.scss": "./_index.scss",
     "./less/base.less": "./less/base.less",
     "./scss/base.scss": "./scss/base.scss",
@@ -40,6 +41,7 @@
     "declarations",
     "dist",
     "ember-basic-dropdown.less",
+    "ember-basic-dropdown.scss",
     "less",
     "scss",
     "vendor"


### PR DESCRIPTION
Add option for consumer apps to use import `@import 'ember-basic-dropdown.scss'`

this works with `ember-cli-scss` only by adding `scssOptions`
```js
let app = new EmberApp(defaults, {
    ...
    sassOptions: {
      includePaths: ['node_modules/ember-basic-dropdown'],
    },
    ...
  });
```