### PR TITLE
Update appReexports

### DIFF
--- a/ember-basic-dropdown/package.json
+++ b/ember-basic-dropdown/package.json
@@ -150,8 +150,7 @@
       "./components/basic-dropdown-trigger.js": "./dist/_app_/components/basic-dropdown-trigger.js",
       "./components/basic-dropdown-wormhole.js": "./dist/_app_/components/basic-dropdown-wormhole.js",
       "./components/basic-dropdown.js": "./dist/_app_/components/basic-dropdown.js",
-      "./modifiers/basic-dropdown-trigger.js": "./dist/_app_/modifiers/basic-dropdown-trigger.js",
-      "./test-support/helpers.js": "./dist/_app_/test-support/helpers.js"
+      "./modifiers/basic-dropdown-trigger.js": "./dist/_app_/modifiers/basic-dropdown-trigger.js"
     }
   }
 }

--- a/ember-basic-dropdown/rollup.config.mjs
+++ b/ember-basic-dropdown/rollup.config.mjs
@@ -39,11 +39,7 @@ export default [
       // These are the modules that should get reexported into the traditional
       // "app" tree. Things in here should also be in publicEntrypoints above, but
       // not everything in publicEntrypoints necessarily needs to go here.
-      addon.appReexports([
-        'components/**/*.js',
-        'modifiers/**/*.js',
-        'test-support/*.js',
-      ]),
+      addon.appReexports(['components/**/*.js', 'modifiers/**/*.js']),
 
       // Follow the V2 Addon rules about dependencies. Your code can import from
       // `dependencies` and `peerDependencies` as well as standard Ember-provided


### PR DESCRIPTION
There is not necessary to add appReexport for `test-support`

This brings warnings in embroider build process like:
```
WARNING in ../../../../ember-basic-dropdown/dist/_app_/test-support/helpers.js 1:0-68
export 'default' (reexported as 'default') was not found in 'ember-basic-dropdown/test-support/helpers' (possible exports: clickTrigger, tapTrigger)
 @ ./assets/test-app.js 16:13-56
```