### PR TITLE
DOCS: Add `destinationElement` to api-reference

### DIFF
--- a/docs/app/templates/public-pages/docs/api-reference.hbs
+++ b/docs/app/templates/public-pages/docs/api-reference.hbs
@@ -42,9 +42,15 @@
     </tr>
     <tr>
       <td>destination</td>
-      <td>String</td>
+      <td><code>String</code></td>
       <td>The id of a DOM element where the dropdown will be rendered using
-        <code>#-in-element</code></td>
+        <code>#in-element</code></td>
+    </tr>
+    <tr>
+      <td>destinationElement</td>
+      <td><code>HTMLElement</code></td>
+      <td>Instead of passing <code>destination</code>, you can pass the DOM element where the dropdown will be rendered using
+        <code>#in-element</code></td>
     </tr>
     <tr>
       <td>contentComponent</td>


### PR DESCRIPTION
Add `destinationElement` in docs which was added in #791 for shadow dom support