### PR TITLE
Fix rollup config (style.js -> styles.js)

### DIFF
--- a/ember-basic-dropdown/rollup.config.mjs
+++ b/ember-basic-dropdown/rollup.config.mjs
@@ -36,7 +36,7 @@ export default [
       // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
       addon.publicEntrypoints([
         'index.js',
-        'style.js',
+        'styles.js',
         'components/**/*.js',
         'modifiers/**/*.js',
         'test-support/**/*.js',


### PR DESCRIPTION
Starting with beta v8.0.0.beta.6 there was missing the `styles.js` export