### PR TITLE
Improve `rootEventType` type and export for EPS

### DIFF
--- a/ember-basic-dropdown/src/components/basic-dropdown-content.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown-content.ts
@@ -10,7 +10,7 @@ import {
 import hasMoved from '../utils/has-moved.ts';
 import { isTesting } from '@embroider/macros';
 import { modifier } from 'ember-modifier';
-import type { Dropdown } from './basic-dropdown.ts';
+import type { Dropdown, TRootEventType } from './basic-dropdown.ts';
 import { runTask } from 'ember-lifeline';
 
 export interface BasicDropdownContentSignature {
@@ -26,7 +26,7 @@ export interface BasicDropdownContentSignature {
     dropdown?: Dropdown;
     renderInPlace?: boolean;
     preventScroll?: boolean;
-    rootEventType?: 'click' | 'mousedown';
+    rootEventType?: TRootEventType;
     top?: string | undefined;
     left?: string | undefined;
     right?: string | undefined;

--- a/ember-basic-dropdown/src/components/basic-dropdown.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown.ts
@@ -33,6 +33,8 @@ export interface Dropdown {
   actions: DropdownActions;
 }
 
+export type TRootEventType = 'click' | 'mousedown';
+
 const UNINITIALIZED = {};
 const IGNORED_STYLES = ['top', 'left', 'right', 'width', 'height'];
 interface BasicDropdownSignature {
@@ -61,7 +63,7 @@ interface BasicDropdownArgs {
   destinationElement?: HTMLElement;
   disabled?: boolean;
   dropdownId?: string;
-  rootEventType?: string;
+  rootEventType?: TRootEventType;
   preventScroll?: boolean;
   matchTriggerWidth?: boolean;
   // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
In PR #903 we have discovered that the type of `rootEventType` was not aligned.

In additional to complete https://github.com/cibernox/ember-power-select/pull/1819 we need to export possible types