### PR TITLE
Fix dropdown not correctly positioned horizontally when body position is relative

### DIFF
--- a/ember-basic-dropdown/src/utils/calculate-position.ts
+++ b/ember-basic-dropdown/src/utils/calculate-position.ts
@@ -93,8 +93,21 @@ export const calculateWormholedPosition: CalculatePosition = (
     style.width = dropdownWidth;
   }
 
+  /**
+   * Fixes bug where the dropdown always stays on the same position on the screen when
+   * the <body> is relatively positioned
+   */
+  const isBodyPositionRelative =
+    window.getComputedStyle(document.body).getPropertyValue('position') ===
+    'relative';
+
   // Calculate horizontal position
-  const triggerLeftWithScroll = triggerLeft + scroll.left;
+  let triggerLeftWithScroll = triggerLeft;
+
+  if (!isBodyPositionRelative) {
+    triggerLeftWithScroll += scroll.left;
+  }
+
   if (horizontalPosition === 'auto' || horizontalPosition === 'auto-left') {
     // Calculate the number of visible horizontal pixels if we were to place the
     // dropdown on the left and right
@@ -151,13 +164,6 @@ export const calculateWormholedPosition: CalculatePosition = (
   // Calculate vertical position
   let triggerTopWithScroll = triggerTop;
 
-  /**
-   * Fixes bug where the dropdown always stays on the same position on the screen when
-   * the <body> is relatively positioned
-   */
-  const isBodyPositionRelative =
-    window.getComputedStyle(document.body).getPropertyValue('position') ===
-    'relative';
   if (!isBodyPositionRelative) {
     triggerTopWithScroll += scroll.top;
   }


### PR DESCRIPTION
## Why

We noticed that in certain use cases the dropdown is not correctly positioned horizontally when the body is set to `position: relative` and you scroll horizontally. When digging through some issues and the code I discovered this [fix](https://github.com/cibernox/ember-basic-dropdown/pull/333) for vertical positioning. I believe that we should also implement a similar fix for horizontal positioning. We've patched this dependency in our own app and have verified that it works.

Reproducible use case (scroll to the right, then open a dropdown): https://stackblitz.com/edit/ember-cli-editor-output-1hdarw?file=app%2Ftemplates%2Fapplication.hbs,app%2Fstyles%2Fapp.css,app%2Fapp.js&title=Ember%20Starter

<img width="483" alt="Screenshot 2024-06-18 at 15 37 38" src="https://github.com/cibernox/ember-basic-dropdown/assets/10011712/100a057f-5d06-48c6-aa82-1754b1672f3a">
