### PR TITLE
Add push dist workflow

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,35 @@
+﻿# Because this library needs to be built,
+# we can't easily point package.json files at the git repo for easy cross-repo testing.
+#
+# This workflow brings back that capability by placing the compiled assets on a "dist" branch
+# (configurable via the "branch" option below)
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v2.0.0
+        with:
+          branch: dist
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: 'ember-basic-dropdown'


### PR DESCRIPTION
Discoverd that there is atm missing the dist push, which was added in addon-blueprint