### PR TITLE
Export interface `CalculatePositionOptions`

### DIFF
--- a/ember-basic-dropdown/src/utils/calculate-position.ts
+++ b/ember-basic-dropdown/src/utils/calculate-position.ts
@@ -7,7 +7,7 @@ export type HorizontalPosition =
   | 'right'
   | 'center';
 
-interface CalculatePositionOptions {
+export interface CalculatePositionOptions {
   horizontalPosition: HorizontalPosition;
   verticalPosition: VerticalPosition;
   matchTriggerWidth: boolean;


### PR DESCRIPTION
In some parts of our app, when we override the calculatePosition we have necessary to use types of `CalculatePositionOptions`. We should export it