### PR TITLE
Export interfaces `BasicDropdownSignature`, `BasicDropdownArgs` and `BasicDropdownDefaultBlock`

### DIFF
--- a/ember-basic-dropdown/src/components/basic-dropdown.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown.ts
@@ -26,6 +26,7 @@ export interface DropdownActions {
   registerDropdownElement: (e: HTMLElement) => void;
   getTriggerElement: () => HTMLElement | null;
 }
+
 export interface Dropdown {
   uniqueId: string;
   disabled: boolean;
@@ -37,20 +38,21 @@ export type TRootEventType = 'click' | 'mousedown';
 
 const UNINITIALIZED = {};
 const IGNORED_STYLES = ['top', 'left', 'right', 'width', 'height'];
+
+export interface BasicDropdownDefaultBlock {
+  uniqueId: string;
+  disabled: boolean;
+  isOpen: boolean;
+  actions: DropdownActions;
+  Trigger: ComponentLike<BasicDropdownTriggerSignature>;
+  Content: ComponentLike<BasicDropdownContentSignature>;
+}
+
 export interface BasicDropdownSignature {
   Element: HTMLElement;
   Args: BasicDropdownArgs;
   Blocks: {
-    default: [
-      {
-        uniqueId: string;
-        disabled: boolean;
-        isOpen: boolean;
-        actions: DropdownActions;
-        Trigger: ComponentLike<BasicDropdownTriggerSignature>;
-        Content: ComponentLike<BasicDropdownContentSignature>;
-      },
-    ];
+    default: [BasicDropdownDefaultBlock];
   };
 }
 

--- a/ember-basic-dropdown/src/components/basic-dropdown.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown.ts
@@ -37,7 +37,7 @@ export type TRootEventType = 'click' | 'mousedown';
 
 const UNINITIALIZED = {};
 const IGNORED_STYLES = ['top', 'left', 'right', 'width', 'height'];
-interface BasicDropdownSignature {
+export interface BasicDropdownSignature {
   Element: HTMLElement;
   Args: BasicDropdownArgs;
   Blocks: {
@@ -54,7 +54,7 @@ interface BasicDropdownSignature {
   };
 }
 
-interface BasicDropdownArgs {
+export interface BasicDropdownArgs {
   initiallyOpened?: boolean;
   renderInPlace?: boolean;
   verticalPosition?: VerticalPosition;


### PR DESCRIPTION
This adds two missing exports for `BasicDropdown`. These exports help, e.g., to correctly reference and type the Dropdown's blocks in components re-yielding the `BasicDropdown` blocks.

