### PR TITLE
Reactivate eslint rules & improve typings

### DIFF
--- a/ember-basic-dropdown/eslint.config.mjs
+++ b/ember-basic-dropdown/eslint.config.mjs
@@ -85,9 +85,6 @@ export default ts.config(
       parserOptions: parserOptions.esm.ts,
     },
     extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
-    rules: {
-      '@typescript-eslint/no-unsafe-call': 'off',
-    },
   },
   {
     files: ['src/**/*'],

--- a/ember-basic-dropdown/eslint.config.mjs
+++ b/ember-basic-dropdown/eslint.config.mjs
@@ -87,7 +87,6 @@ export default ts.config(
     extends: [...ts.configs.recommendedTypeChecked, ember.configs.gts],
     rules: {
       '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/unbound-method': 'off',
     },
   },
   {

--- a/ember-basic-dropdown/src/components/basic-dropdown-content.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown-content.ts
@@ -202,17 +202,17 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
         );
       }
 
-      window.addEventListener('resize', this.runloopAwareReposition);
-      window.addEventListener('orientationchange', this.runloopAwareReposition);
+      window.addEventListener('resize', this.runloopAwareRepositionBound);
+      window.addEventListener('orientationchange', this.runloopAwareRepositionBound);
 
       if (this.isTouchDevice) {
-        document.addEventListener('touchstart', this.touchStartHandler, true);
+        document.addEventListener('touchstart', this.touchStartHandlerBound, true);
         document.addEventListener('touchend', this.handleRootMouseDown, true);
 
         if (rootElement) {
           rootElement.addEventListener(
             'touchstart',
-            this.touchStartHandler,
+            this.touchStartHandlerBound,
             true,
           );
           rootElement.addEventListener(
@@ -259,7 +259,7 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
         if (this.isTouchDevice) {
           document.removeEventListener(
             'touchstart',
-            this.touchStartHandler,
+            this.touchStartHandlerBound,
             true,
           );
           document.removeEventListener(
@@ -271,7 +271,7 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
           if (rootElement) {
             rootElement.removeEventListener(
               'touchstart',
-              this.touchStartHandler,
+              this.touchStartHandlerBound,
               true,
             );
             rootElement.removeEventListener(
@@ -369,28 +369,28 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
 
   @action
   touchStartHandler(): void {
-    document.addEventListener('touchmove', this.touchMoveHandler, true);
+    document.addEventListener('touchmove', this.touchMoveHandlerBound, true);
 
     if (
       this._contentWormhole &&
       this._contentWormhole.getRootNode() instanceof ShadowRoot
     ) {
       const rootElement = this._contentWormhole.getRootNode() as HTMLElement;
-      rootElement.addEventListener('touchmove', this.touchMoveHandler, true);
+      rootElement.addEventListener('touchmove', this.touchMoveHandlerBound, true);
     }
   }
 
   @action
   touchMoveHandler(e: TouchEvent): void {
     this.touchMoveEvent = e;
-    document.removeEventListener('touchmove', this.touchMoveHandler, true);
+    document.removeEventListener('touchmove', this.touchMoveHandlerBound, true);
 
     if (
       this._contentWormhole &&
       this._contentWormhole.getRootNode() instanceof ShadowRoot
     ) {
       const rootElement = this._contentWormhole.getRootNode() as HTMLElement;
-      rootElement.removeEventListener('touchmove', this.touchMoveHandler, true);
+      rootElement.removeEventListener('touchmove', this.touchMoveHandlerBound, true);
     }
   }
 
@@ -411,12 +411,16 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
 
   @action
   removeGlobalEvents(): void {
-    window.removeEventListener('resize', this.runloopAwareReposition);
+    window.removeEventListener('resize', this.runloopAwareRepositionBound);
     window.removeEventListener(
       'orientationchange',
-      this.runloopAwareReposition,
+      this.runloopAwareRepositionBound,
     );
   }
+
+  touchMoveHandlerBound = (e: TouchEvent) => this.touchMoveHandler(e);
+  runloopAwareRepositionBound = () => this.runloopAwareReposition();
+  touchStartHandlerBound = () => this.touchStartHandler();
 
   // Methods
   addScrollHandling(dropdownElement: Element): void {
@@ -497,7 +501,7 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
       };
     } else {
       this.addScrollEvents();
-      this.removeScrollHandling = this.removeScrollEvents;
+      this.removeScrollHandling = this.removeScrollEvents.bind(this);
     }
   }
 
@@ -508,15 +512,15 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
   // These two functions wire up scroll handling if `preventScroll` is false.
   // These trigger reposition of the dropdown.
   addScrollEvents(): void {
-    window.addEventListener('scroll', this.runloopAwareReposition);
+    window.addEventListener('scroll', this.runloopAwareRepositionBound);
     this.scrollableAncestors.forEach((el) => {
-      el.addEventListener('scroll', this.runloopAwareReposition);
+      el.addEventListener('scroll', this.runloopAwareRepositionBound);
     });
   }
   removeScrollEvents(): void {
-    window.removeEventListener('scroll', this.runloopAwareReposition);
+    window.removeEventListener('scroll', this.runloopAwareRepositionBound);
     this.scrollableAncestors.forEach((el) => {
-      el.removeEventListener('scroll', this.runloopAwareReposition);
+      el.removeEventListener('scroll', this.runloopAwareRepositionBound);
     });
   }
 }

--- a/ember-basic-dropdown/src/components/basic-dropdown-content.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown-content.ts
@@ -203,10 +203,17 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
       }
 
       window.addEventListener('resize', this.runloopAwareRepositionBound);
-      window.addEventListener('orientationchange', this.runloopAwareRepositionBound);
+      window.addEventListener(
+        'orientationchange',
+        this.runloopAwareRepositionBound,
+      );
 
       if (this.isTouchDevice) {
-        document.addEventListener('touchstart', this.touchStartHandlerBound, true);
+        document.addEventListener(
+          'touchstart',
+          this.touchStartHandlerBound,
+          true,
+        );
         document.addEventListener('touchend', this.handleRootMouseDown, true);
 
         if (rootElement) {
@@ -376,7 +383,11 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
       this._contentWormhole.getRootNode() instanceof ShadowRoot
     ) {
       const rootElement = this._contentWormhole.getRootNode() as HTMLElement;
-      rootElement.addEventListener('touchmove', this.touchMoveHandlerBound, true);
+      rootElement.addEventListener(
+        'touchmove',
+        this.touchMoveHandlerBound,
+        true,
+      );
     }
   }
 
@@ -390,7 +401,11 @@ export default class BasicDropdownContent extends Component<BasicDropdownContent
       this._contentWormhole.getRootNode() instanceof ShadowRoot
     ) {
       const rootElement = this._contentWormhole.getRootNode() as HTMLElement;
-      rootElement.removeEventListener('touchmove', this.touchMoveHandlerBound, true);
+      rootElement.removeEventListener(
+        'touchmove',
+        this.touchMoveHandlerBound,
+        true,
+      );
     }
   }
 
@@ -577,8 +592,7 @@ function closestContent(el: Element): Element | null {
   return el;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-function waitForAnimations(element: Element, callback: Function): void {
+function waitForAnimations(element: Element, callback: () => void): void {
   window.requestAnimationFrame(function () {
     const computedStyle = window.getComputedStyle(element);
     if (

--- a/ember-basic-dropdown/src/components/basic-dropdown-wormhole.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown-wormhole.ts
@@ -9,6 +9,7 @@ export default class BasicDropdownWormholeComponent extends Component<BasicDropd
   get getDestinationId(): string {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const config = getOwner(this).resolveRegistration('config:environment') as {
       'ember-basic-dropdown'?: {
         destination?: string;

--- a/ember-basic-dropdown/src/components/basic-dropdown.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown.ts
@@ -68,18 +68,18 @@ export interface BasicDropdownArgs {
   rootEventType?: TRootEventType;
   preventScroll?: boolean;
   matchTriggerWidth?: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onInit?: Function;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  registerAPI?: Function;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onOpen?: Function;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onClose?: Function;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  triggerComponent?: string | ComponentLike<any> | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  contentComponent?: string | ComponentLike<any> | undefined;
+  onInit?: (dropdown: Dropdown) => void;
+  registerAPI?: (dropdown: Dropdown | null) => void;
+  onOpen?: (dropdown: Dropdown, e?: Event) => boolean | void;
+  onClose?: (dropdown: Dropdown, e?: Event) => boolean | void;
+  triggerComponent?:
+    | string
+    | ComponentLike<BasicDropdownTriggerSignature>
+    | undefined;
+  contentComponent?:
+    | string
+    | ComponentLike<BasicDropdownContentSignature>
+    | undefined;
   calculatePosition?: CalculatePosition;
 }
 
@@ -394,6 +394,7 @@ export default class BasicDropdown extends Component<BasicDropdownSignature> {
   _getDestinationId(): string {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     const config = getOwner(this).resolveRegistration('config:environment') as {
       environment: string;
       APP: {

--- a/ember-basic-dropdown/src/components/basic-dropdown.ts
+++ b/ember-basic-dropdown/src/components/basic-dropdown.ts
@@ -116,12 +116,12 @@ export default class BasicDropdown extends Component<BasicDropdownSignature> {
     this.args.dropdownId || `ember-basic-dropdown-content-${this._uid}`;
   private _previousDisabled = UNINITIALIZED;
   private _actions: DropdownActions = {
-    open: this.open,
-    close: this.close,
-    toggle: this.toggle,
-    reposition: this.reposition,
-    registerTriggerElement: this.registerTriggerElement,
-    registerDropdownElement: this.registerDropdownElement,
+    open: this.open.bind(this),
+    close: this.close.bind(this),
+    toggle: this.toggle.bind(this),
+    reposition: this.reposition.bind(this),
+    registerTriggerElement: this.registerTriggerElement.bind(this),
+    registerDropdownElement: this.registerDropdownElement.bind(this),
     getTriggerElement: () => this.triggerElement,
   };
 

--- a/ember-basic-dropdown/src/modifiers/basic-dropdown-trigger.ts
+++ b/ember-basic-dropdown/src/modifiers/basic-dropdown-trigger.ts
@@ -238,9 +238,18 @@ function cleanup(instance: DropdownTriggerModifier) {
     }
 
     triggerElement.removeEventListener('click', instance.handleMouseEventBound);
-    triggerElement.removeEventListener('mousedown', instance.handleMouseEventBound);
+    triggerElement.removeEventListener(
+      'mousedown',
+      instance.handleMouseEventBound,
+    );
     triggerElement.removeEventListener('keydown', instance.handleKeyDownBound);
-    triggerElement.removeEventListener('touchstart', instance.handleTouchStartBound);
-    triggerElement.removeEventListener('touchend', instance.handleTouchEndBound);
+    triggerElement.removeEventListener(
+      'touchstart',
+      instance.handleTouchStartBound,
+    );
+    triggerElement.removeEventListener(
+      'touchend',
+      instance.handleTouchEndBound,
+    );
   }
 }

--- a/ember-basic-dropdown/src/utils/calculate-position.ts
+++ b/ember-basic-dropdown/src/utils/calculate-position.ts
@@ -1,3 +1,5 @@
+import type BasicDropdown from '../components/basic-dropdown';
+
 export type VerticalPosition = 'auto' | 'above' | 'below';
 export type HorizontalPosition =
   | 'auto'
@@ -14,8 +16,7 @@ export interface CalculatePositionOptions {
   previousHorizontalPosition?: HorizontalPosition | undefined;
   previousVerticalPosition?: VerticalPosition | undefined;
   renderInPlace: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dropdown: any;
+  dropdown: BasicDropdown;
 }
 export type CalculatePositionResultStyle = {
   top?: number | undefined;


### PR DESCRIPTION
When we were moved from 5.12 to 6.1 we have disabled some eslint rules.

Now we fix this issues and do also improve typing. We remove latest `any` and `Function`

To fix unbound function there was necessary to make a workaround inside addon, so we don't need to publish this as braking