### PR TITLE
Remove ember-source and glimmer tracking as a peer dependency

### DIFF
--- a/ember-basic-dropdown/package.json
+++ b/ember-basic-dropdown/package.json
@@ -109,10 +109,8 @@
     "webpack": "^5.97.1"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0",
     "@ember/test-helpers": "^2.9.4 || ^3.2.1 || ^4.0.2 || ^5.0.0",
-    "@glimmer/component": "^1.1.2 || ^2.0.0",
-    "@glimmer/tracking": "^1.1.2"
+    "@glimmer/component": "^1.1.2 || ^2.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
- @glimmer/tracking is provided by ember-source
- ember-source is assumed by both embroider and ember-cli in ways that it doesn't actually need to be a peer, and having it as one creates potential for duplicate copies that create errors in apps