### PR TITLE
Remove broken v1 docs link

### DIFF
--- a/docs/app/templates/public-pages.hbs
+++ b/docs/app/templates/public-pages.hbs
@@ -49,11 +49,6 @@
 <div class="main-content">
   {{outlet}}
 </div>
-<aside class="link-to-other-version">
-  This is the documentation for version 2.X of the addon. If you are looking for
-  version 1.X you can find the docs
-  <a href="https://1-x.ember-basic-dropdown.com">here</a>
-</aside>
 <footer class="main-footer">
   <div class="main-footer-content">
     Deployed with love by


### PR DESCRIPTION
Seen in docs, that we have a link to v1 docs, which is broken. V1 is very old so we don't need to fix it