### PR TITLE
add a test for ember 3.28

### DIFF
--- a/.try.mjs
+++ b/.try.mjs
@@ -26,6 +26,21 @@ const compatDeps = {
 export default {
   scenarios: [
     {
+      name: 'ember-lts-3.28',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.28.0',
+          '@glimmer/component': '^1.0.0',
+          ...compatDeps,
+          'ember-cli': '~4.12.0',
+        },
+      },
+      env: {
+        ENABLE_COMPAT_BUILD: true,
+      },
+      files: compatFiles,
+    },
+    {
       name: 'ember-lts-4.12',
       npm: {
         devDependencies: {


### PR DESCRIPTION
I noticed when evaluating an Ember upgrade that ember-basic-dropdown doesn't say that it has support for ember@3.28, but I had a hunch that there was nothing in the codebase that actually prevented it from working.

Now that it's a v2 addon and on the new v2 addon blueprint it's quite easy to see that it does still have support for 3.28 🎉 I don't know if y'all might want to consider merging this to add back the official support, it can be quite useful to people who are upgrading really old apps to 3.28 and then migrating to Vite

Edit: I ran this PR's CI on my own fork to show that it was actually working: https://github.com/mansona/ember-basic-dropdown/actions/runs/22722030628/job/65886672854 so you will see CI go green once you approve running the CI job 👍 