### PR TITLE
Remove `Component` keyword in class name (BasicDropdownWormholeComponent -> BasicDropdownWormhole)

### DIFF
--- a/src/components/basic-dropdown-wormhole.gts
+++ b/src/components/basic-dropdown-wormhole.gts
@@ -5,7 +5,7 @@ export interface BasicDropdownWormholeSignature {
   Element: HTMLElement;
 }
 
-export default class BasicDropdownWormholeComponent extends Component<BasicDropdownWormholeSignature> {
+export default class BasicDropdownWormhole extends Component<BasicDropdownWormholeSignature> {
   get getDestinationId(): string {
     const config = getConfig();
 


### PR DESCRIPTION
Rename class `BasicDropdownWormholeComponent` to ` BasicDropdownWormhole` to follow ember-cli default for components