### PR TITLE
Add sass/css export into package.json

### DIFF
--- a/ember-basic-dropdown/package.json
+++ b/ember-basic-dropdown/package.json
@@ -8,9 +8,12 @@
   "repository": "https://github.com/cibernox/ember-basic-dropdown",
   "license": "MIT",
   "author": "Miguel Camba",
+  "sass": "./ember-basic-dropdown.scss",
+  "style": "./dist/vendor/ember-basic-dropdown.css",
   "exports": {
     ".": {
       "types": "./declarations/index.d.ts",
+      "sass": "./ember-basic-dropdown.scss",
       "default": "./dist/index.js"
     },
     "./*": {


### PR DESCRIPTION
While updating the dependencies (https://github.com/ember-power-addons/ember-basic-dropdown/pull/1123), I discovered that the Sass/style exports are missing from `package.json`.

Adding the SCSS exports enables support for importing SCSS via `pkg:` imports (for example, `@use "pkg:ember-basic-dropdown"`). This has been supported since Dart Sass v1.71.0: [[Announcing pkg: Importers](https://sass-lang.com/blog/announcing-pkg-importers/?utm_source=chatgpt.com)](https://sass-lang.com/blog/announcing-pkg-importers/?utm_source=chatgpt.com)

For Vite apps, you need the following setup:

```js
import { defineConfig } from 'vite';
import { NodePackageImporter } from "sass-embedded";

export default defineConfig({
  css: {
    preprocessorOptions: {
      scss: {
        api: "modern-compiler",
        importers: [new NodePackageImporter()],
      },
    },
  },
  ...
});
```